### PR TITLE
Add Hospitality Hub placeholder app

### DIFF
--- a/routes.json
+++ b/routes.json
@@ -5,6 +5,8 @@
   "/activity",
   "/big-up",
   "/big-up/app",
+  "/hospitality-hub",
+  "/hospitality-hub/app",
   "/business-processes",
   "/business-processes/:uniqueId",
   "/business-processes/create",

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/HospitalityHubSplashScreen.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/HospitalityHubSplashScreen.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import LoadingBar from "@/components/LoadingBar/LoadingBar";
+import { Center, VStack, Text } from "@chakra-ui/react";
+
+export const HospitalityHubSplashScreen = () => {
+  return (
+    <Center flex={1}>
+      <VStack spacing={4}>
+        <Text fontSize="3xl" fontWeight="bold">
+          Hospitality Hub
+        </Text>
+        <LoadingBar />
+      </VStack>
+    </Center>
+  );
+};

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function HospitalityHubPage() {
+  return <></>;
+}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/page.tsx
@@ -1,0 +1,28 @@
+import { ToolLandingPage } from "@/app/(site)/(apps)/ToolLandingPageInner";
+import { HospitalityHubSplashScreen } from "./HospitalityHubSplashScreen";
+import apiClient from "@/lib/apiClient";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function Home() {
+  const redirectUrl = "/hospitality-hub/app";
+  const cookieStore = cookies();
+  const uniqueId = cookieStore.get("user_uuid")?.value;
+  const res = await apiClient(`/getUserMetadata`, {
+    method: "POST",
+    body: JSON.stringify({ p_userUniqueId: uniqueId }),
+    cache: "no-store",
+  });
+  const userMetadataData = await res.json();
+  const userMetadata = userMetadataData.resource;
+  if (!userMetadata?.subscribedTools?.includes("100")) {
+    redirect("/");
+  }
+
+  return (
+    <ToolLandingPage
+      redirectUrl={redirectUrl}
+      splashScreen={<HospitalityHubSplashScreen />}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- create new Hospitality Hub app path following Big Up pattern
- add placeholder splash screen
- add server page using ToolLandingPage
- add empty client inner
- register routes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68405fd7a0848326b04deafbd73f0245