### PR TITLE
Add Hospitality Hub masonry layout

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Box, Image, SimpleGrid, Text } from "@chakra-ui/react";
+
+interface HubCard {
+  title: string;
+  image: string;
+}
+
+const cards: HubCard[] = [
+  { title: "Hotels", image: "/big-up/big-up-app-bg.webp" },
+  { title: "Rewards", image: "/carousel/enps-carousel-bg.webp" },
+  { title: "Events", image: "/carousel/happiness-score-carousel-bg.webp" },
+  { title: "Medical", image: "/carousel/business-score-carousel-bg.webp" },
+  { title: "Legal", image: "/carousel/client-satisfaction-bg.webp" },
+];
+
+export function HospitalityHubMasonry() {
+  return (
+    <SimpleGrid columns={[2, 3, 5]} gap={4} w="100%">
+      {cards.map((card) => (
+        <Box
+          key={card.title}
+          position="relative"
+          h="700px"
+          borderRadius="lg"
+          overflow="hidden"
+          role="group"
+        >
+          <Image src={card.image} alt={card.title} objectFit="cover" w="100%" h="100%" />
+          <Box
+            position="absolute"
+            top={0}
+            left={0}
+            w="100%"
+            h="100%"
+            bg="rgba(0,0,0,0.6)"
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            opacity={0}
+            transition="opacity 0.3s"
+            _groupHover={{ opacity: 1 }}
+          >
+            <Text color="white" fontWeight="bold" fontSize="xl">
+              {card.title}
+            </Text>
+          </Box>
+        </Box>
+      ))}
+    </SimpleGrid>
+  );
+}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
@@ -1,53 +1,5 @@
-"use client";
-
-import { Box, Image, SimpleGrid, Text } from "@chakra-ui/react";
-
-interface HubCard {
-  title: string;
-  image: string;
-}
-
-const cards: HubCard[] = [
-  { title: "Hotels", image: "/big-up/big-up-app-bg.webp" },
-  { title: "Rewards", image: "/carousel/enps-carousel-bg.webp" },
-  { title: "Events", image: "/carousel/happiness-score-carousel-bg.webp" },
-  { title: "Medical", image: "/carousel/business-score-carousel-bg.webp" },
-  { title: "Legal", image: "/carousel/client-satisfaction-bg.webp" },
-];
+import { HospitalityHubMasonry } from "./components/HospitalityHubMasonry";
 
 export default function HospitalityHubPage() {
-  return (
-    <SimpleGrid columns={[2, 3, 5]} gap={4} w="100%">
-      {cards.map((card) => (
-        <Box
-          key={card.title}
-          position="relative"
-          h="150px"
-          borderRadius="lg"
-          overflow="hidden"
-          role="group"
-        >
-          <Image src={card.image} alt={card.title} objectFit="cover" w="100%" h="100%" />
-          <Box
-            position="absolute"
-            top={0}
-            left={0}
-            w="100%"
-            h="100%"
-            bg="rgba(0,0,0,0.6)"
-            display="flex"
-            justifyContent="center"
-            alignItems="center"
-            opacity={0}
-            transition="opacity 0.3s"
-            _groupHover={{ opacity: 1 }}
-          >
-            <Text color="white" fontWeight="bold" fontSize="xl">
-              {card.title}
-            </Text>
-          </Box>
-        </Box>
-      ))}
-    </SimpleGrid>
-  );
+  return <HospitalityHubMasonry />;
 }

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
@@ -1,5 +1,53 @@
 "use client";
 
+import { Box, Image, SimpleGrid, Text } from "@chakra-ui/react";
+
+interface HubCard {
+  title: string;
+  image: string;
+}
+
+const cards: HubCard[] = [
+  { title: "Hotels", image: "/big-up/big-up-app-bg.webp" },
+  { title: "Rewards", image: "/carousel/enps-carousel-bg.webp" },
+  { title: "Events", image: "/carousel/happiness-score-carousel-bg.webp" },
+  { title: "Medical", image: "/carousel/business-score-carousel-bg.webp" },
+  { title: "Legal", image: "/carousel/client-satisfaction-bg.webp" },
+];
+
 export default function HospitalityHubPage() {
-  return <></>;
+  return (
+    <SimpleGrid columns={[2, 3, 5]} gap={4} w="100%">
+      {cards.map((card) => (
+        <Box
+          key={card.title}
+          position="relative"
+          h="150px"
+          borderRadius="lg"
+          overflow="hidden"
+          role="group"
+        >
+          <Image src={card.image} alt={card.title} objectFit="cover" w="100%" h="100%" />
+          <Box
+            position="absolute"
+            top={0}
+            left={0}
+            w="100%"
+            h="100%"
+            bg="rgba(0,0,0,0.6)"
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            opacity={0}
+            transition="opacity 0.3s"
+            _groupHover={{ opacity: 1 }}
+          >
+            <Text color="white" fontWeight="bold" fontSize="xl">
+              {card.title}
+            </Text>
+          </Box>
+        </Box>
+      ))}
+    </SimpleGrid>
+  );
 }


### PR DESCRIPTION
## Summary
- add card images with hover overlay on the Hospitality Hub app page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406ce56bf88326a1e860b23ac9c30b