### PR TITLE
Add rewards API routes

### DIFF
--- a/src/app/api/hospitality-hub/rewards/[rewardId]/route.ts
+++ b/src/app/api/hospitality-hub/rewards/[rewardId]/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import apiClient from "@/lib/apiClient";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { rewardId: string } },
+) {
+  const { rewardId } = params;
+
+  try {
+    const response = await apiClient(`/hospitality-hub/rewards/${rewardId}`, {
+      method: "GET",
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data?.error || "Failed to fetch reward." },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({ resource: data.resource });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { rewardId: string } },
+) {
+  const { rewardId } = params;
+
+  if (!rewardId) {
+    return NextResponse.json({ error: "rewardId is required." }, { status: 400 });
+  }
+
+  try {
+    const payload = await req.json();
+    const response = await apiClient(`/hospitality-hub/rewards/${rewardId}`, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      const errorMessage = data?.error || "Failed to update reward.";
+      return NextResponse.json(
+        { error: errorMessage },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({ message: "Reward updated successfully" });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message || "An error occurred during the update." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { rewardId: string } },
+) {
+  const { rewardId } = params;
+
+  try {
+    const response = await apiClient(`/hospitality-hub/rewards/${rewardId}`, {
+      method: "DELETE",
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data?.error || "Failed to delete reward." },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({ message: "Reward deleted successfully" });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message || "An error occurred during deletion." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/hospitality-hub/rewards/route.ts
+++ b/src/app/api/hospitality-hub/rewards/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import apiClient from "@/lib/apiClient";
+
+export async function GET(req: NextRequest) {
+  const query = req.nextUrl.searchParams.toString();
+  const endpoint = `/hospitality-hub/rewards${query ? `?${query}` : ""}`;
+
+  try {
+    const response = await apiClient(endpoint, { method: "GET" });
+    const data = await response.json();
+
+    if (!response.ok || response.status !== 200) {
+      const errorMessage = data?.error || "Failed to fetch rewards.";
+      return NextResponse.json(
+        { error: errorMessage },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({ resource: data.resource });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const rewards = await req.json();
+    const response = await apiClient(`/hospitality-hub/rewards`, {
+      method: "POST",
+      body: JSON.stringify(rewards),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data?.error || "Failed to create rewards." },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message || "An error occurred while creating rewards." },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add CRUD API endpoints for Hospitality Hub rewards

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68415ebef07083268efe03c31815acb0