### PR TITLE
Add placeholder images to hospitality hub mock data

### DIFF
--- a/src/app/api/hospitality-hub/mockData/events.ts
+++ b/src/app/api/hospitality-hub/mockData/events.ts
@@ -5,6 +5,7 @@ export const events = [
     date: "2025-06-15",
     location: "Grand Plaza",
     description: "Sample wines from around the world",
+    image: "/carousel/happiness-score-carousel-bg.webp",
   },
   {
     id: "event-2",
@@ -12,6 +13,7 @@ export const events = [
     date: "2025-07-20",
     location: "City Lights Inn",
     description: "Enjoy an evening of smooth jazz",
+    image: "/carousel/happiness-score-carousel-bg.webp",
   },
   {
     id: "event-3",
@@ -19,6 +21,7 @@ export const events = [
     date: "2025-05-10",
     location: "Ocean View Resort",
     description: "Morning yoga session on the beach",
+    image: "/carousel/happiness-score-carousel-bg.webp",
   },
   {
     id: "event-4",
@@ -26,6 +29,7 @@ export const events = [
     date: "2025-08-05",
     location: "Mountain Retreat",
     description: "Learn to cook regional specialties",
+    image: "/carousel/happiness-score-carousel-bg.webp",
   },
   {
     id: "event-5",
@@ -33,5 +37,6 @@ export const events = [
     date: "2025-09-12",
     location: "Desert Oasis",
     description: "Explore the desert with our guided tour",
+    image: "/carousel/happiness-score-carousel-bg.webp",
   },
 ];

--- a/src/app/api/hospitality-hub/mockData/hotels.ts
+++ b/src/app/api/hospitality-hub/mockData/hotels.ts
@@ -5,6 +5,7 @@ export const hotels = [
     location: "New York",
     rating: 4.5,
     description: "Modern hotel in the heart of the city",
+    image: "/big-up/big-up-app-bg.webp",
   },
   {
     id: "hotel-2",
@@ -12,6 +13,7 @@ export const hotels = [
     location: "Miami",
     rating: 4.7,
     description: "Beachfront resort with stunning ocean views",
+    image: "/big-up/big-up-app-bg.webp",
   },
   {
     id: "hotel-3",
@@ -19,6 +21,7 @@ export const hotels = [
     location: "Denver",
     rating: 4.2,
     description: "Cozy lodge near the mountains",
+    image: "/big-up/big-up-app-bg.webp",
   },
   {
     id: "hotel-4",
@@ -26,6 +29,7 @@ export const hotels = [
     location: "Chicago",
     rating: 4.0,
     description: "Boutique hotel near downtown attractions",
+    image: "/big-up/big-up-app-bg.webp",
   },
   {
     id: "hotel-5",
@@ -33,5 +37,6 @@ export const hotels = [
     location: "Phoenix",
     rating: 4.3,
     description: "Relaxing stay in the desert",
+    image: "/big-up/big-up-app-bg.webp",
   },
 ];

--- a/src/app/api/hospitality-hub/mockData/legal.ts
+++ b/src/app/api/hospitality-hub/mockData/legal.ts
@@ -5,6 +5,7 @@ export const legal = [
     speciality: "Corporate",
     location: "New York",
     contact: "555-1111",
+    image: "/carousel/client-satisfaction-bg.webp",
   },
   {
     id: "legal-2",
@@ -12,6 +13,7 @@ export const legal = [
     speciality: "Real Estate",
     location: "Miami",
     contact: "555-2222",
+    image: "/carousel/client-satisfaction-bg.webp",
   },
   {
     id: "legal-3",
@@ -19,6 +21,7 @@ export const legal = [
     speciality: "Employment",
     location: "Denver",
     contact: "555-3333",
+    image: "/carousel/client-satisfaction-bg.webp",
   },
   {
     id: "legal-4",
@@ -26,6 +29,7 @@ export const legal = [
     speciality: "Tax",
     location: "Chicago",
     contact: "555-4444",
+    image: "/carousel/client-satisfaction-bg.webp",
   },
   {
     id: "legal-5",
@@ -33,5 +37,6 @@ export const legal = [
     speciality: "Immigration",
     location: "Phoenix",
     contact: "555-5555",
+    image: "/carousel/client-satisfaction-bg.webp",
   },
 ];

--- a/src/app/api/hospitality-hub/mockData/medical.ts
+++ b/src/app/api/hospitality-hub/mockData/medical.ts
@@ -5,6 +5,7 @@ export const medical = [
     speciality: "General Practice",
     location: "New York",
     contact: "555-1010",
+    image: "/carousel/business-score-carousel-bg.webp",
   },
   {
     id: "medical-2",
@@ -12,6 +13,7 @@ export const medical = [
     speciality: "Physiotherapy",
     location: "Miami",
     contact: "555-2020",
+    image: "/carousel/business-score-carousel-bg.webp",
   },
   {
     id: "medical-3",
@@ -19,6 +21,7 @@ export const medical = [
     speciality: "Cardiology",
     location: "Denver",
     contact: "555-3030",
+    image: "/carousel/business-score-carousel-bg.webp",
   },
   {
     id: "medical-4",
@@ -26,6 +29,7 @@ export const medical = [
     speciality: "Dentistry",
     location: "Chicago",
     contact: "555-4040",
+    image: "/carousel/business-score-carousel-bg.webp",
   },
   {
     id: "medical-5",
@@ -33,5 +37,6 @@ export const medical = [
     speciality: "Dermatology",
     location: "Phoenix",
     contact: "555-5050",
+    image: "/carousel/business-score-carousel-bg.webp",
   },
 ];

--- a/src/app/api/hospitality-hub/mockData/rewards.ts
+++ b/src/app/api/hospitality-hub/mockData/rewards.ts
@@ -5,6 +5,7 @@ export const rewards = [
     points: 100,
     description: "Enjoy a complimentary breakfast during your stay",
     expiryDate: "2025-12-31",
+    image: "/carousel/enps-carousel-bg.webp",
   },
   {
     id: "reward-2",
@@ -12,6 +13,7 @@ export const rewards = [
     points: 150,
     description: "Extend your checkout time by 2 hours",
     expiryDate: "2025-12-31",
+    image: "/carousel/enps-carousel-bg.webp",
   },
   {
     id: "reward-3",
@@ -19,6 +21,7 @@ export const rewards = [
     points: 250,
     description: "Upgrade to the next available room type",
     expiryDate: "2025-12-31",
+    image: "/carousel/enps-carousel-bg.webp",
   },
   {
     id: "reward-4",
@@ -26,6 +29,7 @@ export const rewards = [
     points: 200,
     description: "Receive a voucher for our in-house spa",
     expiryDate: "2025-12-31",
+    image: "/carousel/enps-carousel-bg.webp",
   },
   {
     id: "reward-5",
@@ -33,5 +37,6 @@ export const rewards = [
     points: 75,
     description: "Complimentary parking during your stay",
     expiryDate: "2025-12-31",
+    image: "/carousel/enps-carousel-bg.webp",
   },
 ];


### PR DESCRIPTION
## Summary
- include placeholder `image` fields in Hospitality Hub API mock data so `CategoryItemCard` renders images properly

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416bad7adc83269965457811b9c272