### PR TITLE
Update hospitality hub item interactions

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/CategoryItemCard.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/CategoryItemCard.tsx
@@ -1,23 +1,44 @@
 "use client";
 
-import { VStack, Text, Image } from "@chakra-ui/react";
+import { Box, VStack, Text, Image } from "@chakra-ui/react";
 import PerygonCard from "@/components/layout/PerygonCard";
 
 interface CategoryItemCardProps {
   title: string;
   description?: string;
   image?: string;
+  onClick?: () => void;
 }
 
-export function CategoryItemCard({ title, description, image }: CategoryItemCardProps) {
+export function CategoryItemCard({ title, description, image, onClick }: CategoryItemCardProps) {
   return (
-    <PerygonCard width="100%" height="100%" p={4} display="flex" flexDirection="column">
-      {image && <Image src={image} alt={title} borderRadius="md" mb={2} />}
-      <VStack align="start" spacing={1} flex={1}>
-        <Text fontWeight="bold">{title}</Text>
-        {description && <Text fontSize="sm">{description}</Text>}
-      </VStack>
-    </PerygonCard>
+    <Box position="relative" role="group" cursor="pointer" onClick={onClick} h="100%">
+      <PerygonCard width="100%" height="100%" p={4} display="flex" flexDirection="column">
+        {image && <Image src={image} alt={title} borderRadius="md" mb={2} />}
+        <VStack align="start" spacing={1} flex={1}>
+          <Text fontWeight="bold">{title}</Text>
+          {description && <Text fontSize="sm">{description}</Text>}
+        </VStack>
+      </PerygonCard>
+      <Box
+        position="absolute"
+        top={0}
+        left={0}
+        w="100%"
+        h="100%"
+        bg="rgba(0,0,0,0.6)"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        opacity={0}
+        transition="opacity 0.3s"
+        _groupHover={{ opacity: 1 }}
+      >
+        <Text color="white" fontWeight="bold" fontSize="xl">
+          {title}
+        </Text>
+      </Box>
+    </Box>
   );
 }
 

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import CategoryItemCard from "./CategoryItemCard";
+import ItemDetailModal from "./ItemDetailModal";
 
 interface HubCard {
   title: string;
@@ -28,6 +29,28 @@ export function HospitalityHubMasonry() {
   const [selected, setSelected] = useState<string | null>(null);
   const [items, setItems] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalLoading, setModalLoading] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<any | null>(null);
+
+  const handleItemClick = async (itemId: string) => {
+    if (!selected) return;
+    setModalOpen(true);
+    setModalLoading(true);
+    try {
+      const res = await fetch(
+        `/api/hospitality-hub/${selected.toLowerCase()}/${itemId}`
+      );
+      const data = await res.json();
+      if (res.ok) {
+        setSelectedItem(data.resource);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setModalLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (!selected) return;
@@ -74,9 +97,19 @@ export function HospitalityHubMasonry() {
               title={item.name || item.title}
               description={item.description}
               image={item.image}
+              onClick={() => handleItemClick(item.id)}
             />
           ))}
         </SimpleGrid>
+        <ItemDetailModal
+          isOpen={modalOpen}
+          onClose={() => {
+            setModalOpen(false);
+            setSelectedItem(null);
+          }}
+          item={selectedItem}
+          loading={modalLoading}
+        />
       </Center>
     );
   }

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  Text,
+  Spinner,
+  VStack,
+} from "@chakra-ui/react";
+
+interface ItemDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  item?: any;
+  loading?: boolean;
+}
+
+export const ItemDetailModal = ({ isOpen, onClose, item, loading }: ItemDetailModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg">
+      <ModalOverlay />
+      <ModalContent p={4}>
+        <ModalHeader>{item?.name || item?.title || "Details"}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {loading ? (
+            <Spinner />
+          ) : (
+            <VStack align="start" spacing={2}>
+              {item?.description && <Text>{item.description}</Text>}
+              {item?.location && <Text>Location: {item.location}</Text>}
+              {item?.date && <Text>Date: {item.date}</Text>}
+              {item?.points && <Text>Points: {item.points}</Text>}
+              {item?.rating && <Text>Rating: {item.rating}</Text>}
+              {item?.contact && <Text>Contact: {item.contact}</Text>}
+            </VStack>
+          )}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ItemDetailModal;


### PR DESCRIPTION
## Summary
- add an item details modal for hospitality hub items
- allow item cards to open modal and show hover effect
- wire up modal in hospitality hub masonry

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416c2a0e0083269364e30ef41b8871