### PR TITLE
Fix vertical scrolling for hospitality hub

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
@@ -3,7 +3,7 @@ import { HospitalityHubMasonry } from "./components/HospitalityHubMasonry";
 
 export default function HospitalityHubPage() {
   return (
-    <Center h="100vh" w="100vw" p={4}>
+    <Center minH="100vh" w="100%" p={4}>
       <HospitalityHubMasonry />;
     </Center>
   );

--- a/src/app/(site)/(apps-non-standard)/layout.tsx
+++ b/src/app/(site)/(apps-non-standard)/layout.tsx
@@ -9,7 +9,7 @@ export default async function Layout({ children }: LayoutProps) {
   return (
     <>
       <Flex flex={1} width="100%">
-        <Box flex={1} overflowY="clip">
+        <Box flex={1} overflowY="auto">
           {children}
         </Box>
       </Flex>


### PR DESCRIPTION
## Summary
- adjust apps-non-standard layout to allow vertical scrolling
- let Hospitality Hub page grow beyond viewport height

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416d968b908326a2e7092c251930ef