### PR TITLE
Fix semicolon rendering in Hospitality Hub

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
@@ -4,7 +4,7 @@ import { HospitalityHubMasonry } from "./components/HospitalityHubMasonry";
 export default function HospitalityHubPage() {
   return (
     <Center minH="100vh" w="100%" p={4}>
-      <HospitalityHubMasonry />;
+      <HospitalityHubMasonry />
     </Center>
   );
 }

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
@@ -4,7 +4,7 @@ import { HospitalityHubMasonry } from "./components/HospitalityHubMasonry";
 export default function HospitalityHubPage() {
   return (
     <Center h="100vh" w="100vw" p={4}>
-      <HospitalityHubMasonry />;
+      <HospitalityHubMasonry />
     </Center>
   );
 }


### PR DESCRIPTION
## Summary
- remove stray semicolon from Hospitality Hub page

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841743c4c548326bb70fa371c388cc3