### PR TITLE
Add hospitality hub admin panel

### DIFF
--- a/src/app/(site)/(admin)/hospitality-hub/[category]/[itemId]/page.tsx
+++ b/src/app/(site)/(admin)/hospitality-hub/[category]/[itemId]/page.tsx
@@ -1,0 +1,39 @@
+import AdminHeader from "@/components/AdminHeader";
+import { checkUserRole } from "@/lib/dal";
+import CategoryForm from "../../components/CategoryForm";
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default async function HospitalityItemPage({
+  params,
+}: {
+  params: { category: string; itemId: string };
+}) {
+  await checkUserRole(`/hospitality-hub/${params.category}/${params.itemId}`);
+
+  const baseUrl = process.env.NEXTAUTH_URL || "";
+  const res = await fetch(
+    `${baseUrl}/api/hospitality-hub/${params.category}/${params.itemId}`,
+    { cache: "no-store" }
+  );
+
+  if (!res.ok) {
+    return redirect("/error");
+  }
+
+  const json = await res.json();
+  const item = json.resource;
+  const title = `Edit ${item?.name || item?.provider || "Item"}`;
+
+  return (
+    <>
+      <AdminHeader headingText={title} />
+      <CategoryForm
+        category={params.category}
+        itemId={params.itemId}
+        initialData={item}
+      />
+    </>
+  );
+}

--- a/src/app/(site)/(admin)/hospitality-hub/[category]/create/page.tsx
+++ b/src/app/(site)/(admin)/hospitality-hub/[category]/create/page.tsx
@@ -1,0 +1,14 @@
+import AdminHeader from "@/components/AdminHeader";
+import { checkUserRole } from "@/lib/dal";
+import CategoryForm from "../../components/CategoryForm";
+
+export default async function HospitalityCreatePage({ params }: { params: { category: string } }) {
+  await checkUserRole(`/hospitality-hub/${params.category}/create`);
+  const title = `Create ${params.category.charAt(0).toUpperCase() + params.category.slice(1)}`;
+  return (
+    <>
+      <AdminHeader headingText={title} />
+      <CategoryForm category={params.category} />
+    </>
+  );
+}

--- a/src/app/(site)/(admin)/hospitality-hub/components/CategoryForm.tsx
+++ b/src/app/(site)/(admin)/hospitality-hub/components/CategoryForm.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { VStack, FormControl, FormLabel, Input, Button } from "@chakra-ui/react";
+import { useFetchClient } from "@/hooks/useFetchClient";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface CategoryFormProps {
+  category: string;
+  itemId?: string;
+  initialData?: any;
+}
+
+const fieldsMap: Record<string, { name: string; label: string }[]> = {
+  hotels: [
+    { name: "name", label: "Name" },
+    { name: "location", label: "Location" },
+    { name: "rating", label: "Rating" },
+    { name: "description", label: "Description" },
+    { name: "image", label: "Image URL" },
+  ],
+  rewards: [
+    { name: "name", label: "Name" },
+    { name: "points", label: "Points" },
+    { name: "description", label: "Description" },
+    { name: "expiryDate", label: "Expiry Date" },
+    { name: "image", label: "Image URL" },
+  ],
+  events: [
+    { name: "name", label: "Name" },
+    { name: "date", label: "Date" },
+    { name: "location", label: "Location" },
+    { name: "description", label: "Description" },
+    { name: "image", label: "Image URL" },
+  ],
+  medical: [
+    { name: "provider", label: "Provider" },
+    { name: "speciality", label: "Speciality" },
+    { name: "location", label: "Location" },
+    { name: "contact", label: "Contact" },
+    { name: "image", label: "Image URL" },
+  ],
+  legal: [
+    { name: "provider", label: "Provider" },
+    { name: "speciality", label: "Speciality" },
+    { name: "location", label: "Location" },
+    { name: "contact", label: "Contact" },
+    { name: "image", label: "Image URL" },
+  ],
+};
+
+export default function CategoryForm({ category, itemId, initialData }: CategoryFormProps) {
+  const { fetchClient, loading } = useFetchClient();
+  const router = useRouter();
+  const [formData, setFormData] = useState<any>(initialData || {});
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async () => {
+    const method = itemId ? "PUT" : "POST";
+    const url = itemId
+      ? `/api/hospitality-hub/${category}/${itemId}`
+      : `/api/hospitality-hub/${category}`;
+
+    const result = await fetchClient(url, {
+      method,
+      body: formData,
+      successMessage: itemId ? "Updated successfully" : "Created successfully",
+      redirectOnError: false,
+    });
+
+    if (result) {
+      router.push(`/hospitality-hub/admin`);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!itemId) return;
+    if (!confirm("Are you sure you want to delete this item?")) return;
+
+    const result = await fetchClient(`/api/hospitality-hub/${category}/${itemId}`,
+      {
+        method: "DELETE",
+        successMessage: "Deleted successfully",
+        redirectOnError: false,
+      });
+
+    if (result) {
+      router.push(`/hospitality-hub/admin`);
+    }
+  };
+
+  const fields = fieldsMap[category] || [];
+
+  return (
+    <VStack spacing={4} align="stretch" mt={4}>
+      {fields.map((field) => (
+        <FormControl key={field.name}>
+          <FormLabel>{field.label}</FormLabel>
+          <Input
+            name={field.name}
+            value={formData[field.name] || ""}
+            onChange={handleChange}
+          />
+        </FormControl>
+      ))}
+      <Button onClick={handleSubmit} isLoading={loading} colorScheme="blue">
+        {itemId ? "Update" : "Create"}
+      </Button>
+      {itemId && (
+        <Button onClick={handleDelete} colorScheme="red" isLoading={loading}>
+          Delete
+        </Button>
+      )}
+    </VStack>
+  );
+}

--- a/src/app/(site)/(admin)/hospitality-hub/page.tsx
+++ b/src/app/(site)/(admin)/hospitality-hub/page.tsx
@@ -1,0 +1,68 @@
+import AdminHeader from "@/components/AdminHeader";
+import TabbedGrids from "@/components/agGrids/TabbedGrids";
+import { hotelsFields, rewardsFields, eventsFields, medicalFields, legalFields } from "@/components/agGrids/dataFields/hospitalityHubFields";
+import { checkUserRole } from "@/lib/dal";
+
+export const dynamic = "force-dynamic";
+
+export default async function HospitalityHubAdminPage() {
+  await checkUserRole("/hospitality-hub");
+
+  const baseUrl = process.env.NEXTAUTH_URL || "";
+
+  const [hotelsRes, rewardsRes, eventsRes, medicalRes, legalRes] = await Promise.all([
+    fetch(`${baseUrl}/api/hospitality-hub/hotels`, { cache: "no-store" }),
+    fetch(`${baseUrl}/api/hospitality-hub/rewards`, { cache: "no-store" }),
+    fetch(`${baseUrl}/api/hospitality-hub/events`, { cache: "no-store" }),
+    fetch(`${baseUrl}/api/hospitality-hub/medical`, { cache: "no-store" }),
+    fetch(`${baseUrl}/api/hospitality-hub/legal`, { cache: "no-store" }),
+  ]);
+
+  const [hotelsJson, rewardsJson, eventsJson, medicalJson, legalJson] = await Promise.all([
+    hotelsRes.json(),
+    rewardsRes.json(),
+    eventsRes.json(),
+    medicalRes.json(),
+    legalRes.json(),
+  ]);
+
+  const dataSources = [
+    {
+      data: hotelsJson.resource || [],
+      title: "Hotels",
+      fields: hotelsFields,
+      createNewUrl: "/hospitality-hub/admin/hotels/create",
+    },
+    {
+      data: rewardsJson.resource || [],
+      title: "Rewards",
+      fields: rewardsFields,
+      createNewUrl: "/hospitality-hub/admin/rewards/create",
+    },
+    {
+      data: eventsJson.resource || [],
+      title: "Events",
+      fields: eventsFields,
+      createNewUrl: "/hospitality-hub/admin/events/create",
+    },
+    {
+      data: medicalJson.resource || [],
+      title: "Medical",
+      fields: medicalFields,
+      createNewUrl: "/hospitality-hub/admin/medical/create",
+    },
+    {
+      data: legalJson.resource || [],
+      title: "Legal",
+      fields: legalFields,
+      createNewUrl: "/hospitality-hub/admin/legal/create",
+    },
+  ];
+
+  return (
+    <>
+      <AdminHeader headingText="Hospitality Hub Admin" />
+      <TabbedGrids dataSources={dataSources} />
+    </>
+  );
+}

--- a/src/components/agGrids/CellRenderers/HospitalityLinkRenderer.tsx
+++ b/src/components/agGrids/CellRenderers/HospitalityLinkRenderer.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { Flex, Text } from "@chakra-ui/react";
+import { CustomCellRendererProps } from "ag-grid-react";
+
+interface HospitalityLinkRendererProps extends CustomCellRendererProps {
+  category: string;
+  nameField: string;
+  idField: string;
+}
+
+const HospitalityLinkRenderer: React.FC<HospitalityLinkRendererProps> = ({
+  node,
+  category,
+  nameField,
+  idField,
+}) => {
+  const item = node?.data;
+  if (!item) return null;
+
+  const name = item[nameField] ?? "Item";
+  const id = item[idField];
+  const link = id ? `/hospitality-hub/admin/${category}/${id}` : null;
+
+  const content = (
+    <Flex alignItems="center" justifyContent="flex-start" w="full" h="full">
+      <Text
+        fontSize="13px"
+        flex={1}
+        overflow="hidden"
+        textOverflow="ellipsis"
+        whiteSpace="nowrap"
+      >
+        {name}
+      </Text>
+    </Flex>
+  );
+
+  return link ? <Link href={link}>{content}</Link> : content;
+};
+
+export default HospitalityLinkRenderer;

--- a/src/components/agGrids/dataFields/hospitalityHubFields.ts
+++ b/src/components/agGrids/dataFields/hospitalityHubFields.ts
@@ -1,0 +1,67 @@
+import { ColDef } from "ag-grid-community";
+import HospitalityLinkRenderer from "@/components/agGrids/CellRenderers/HospitalityLinkRenderer";
+
+export const hotelsFields: ColDef[] = [
+  { field: "id", headerName: "ID", maxWidth: 128, minWidth: 64 },
+  {
+    field: "name",
+    headerName: "Name",
+    filter: "agMultiColumnFilter",
+    cellRenderer: HospitalityLinkRenderer,
+    cellRendererParams: { category: "hotels", nameField: "name", idField: "id" },
+  },
+  { field: "location", headerName: "Location", filter: "agMultiColumnFilter" },
+  { field: "rating", headerName: "Rating", filter: "agNumberColumnFilter" },
+];
+
+export const rewardsFields: ColDef[] = [
+  { field: "id", headerName: "ID", maxWidth: 128, minWidth: 64 },
+  {
+    field: "name",
+    headerName: "Name",
+    filter: "agMultiColumnFilter",
+    cellRenderer: HospitalityLinkRenderer,
+    cellRendererParams: { category: "rewards", nameField: "name", idField: "id" },
+  },
+  { field: "points", headerName: "Points", filter: "agNumberColumnFilter" },
+  { field: "expiryDate", headerName: "Expiry", filter: "agDateColumnFilter" },
+];
+
+export const eventsFields: ColDef[] = [
+  { field: "id", headerName: "ID", maxWidth: 128, minWidth: 64 },
+  {
+    field: "name",
+    headerName: "Name",
+    filter: "agMultiColumnFilter",
+    cellRenderer: HospitalityLinkRenderer,
+    cellRendererParams: { category: "events", nameField: "name", idField: "id" },
+  },
+  { field: "date", headerName: "Date", filter: "agDateColumnFilter" },
+  { field: "location", headerName: "Location", filter: "agMultiColumnFilter" },
+];
+
+export const medicalFields: ColDef[] = [
+  { field: "id", headerName: "ID", maxWidth: 128, minWidth: 64 },
+  {
+    field: "provider",
+    headerName: "Provider",
+    filter: "agMultiColumnFilter",
+    cellRenderer: HospitalityLinkRenderer,
+    cellRendererParams: { category: "medical", nameField: "provider", idField: "id" },
+  },
+  { field: "speciality", headerName: "Speciality", filter: "agMultiColumnFilter" },
+  { field: "location", headerName: "Location", filter: "agMultiColumnFilter" },
+];
+
+export const legalFields: ColDef[] = [
+  { field: "id", headerName: "ID", maxWidth: 128, minWidth: 64 },
+  {
+    field: "provider",
+    headerName: "Provider",
+    filter: "agMultiColumnFilter",
+    cellRenderer: HospitalityLinkRenderer,
+    cellRendererParams: { category: "legal", nameField: "provider", idField: "id" },
+  },
+  { field: "speciality", headerName: "Speciality", filter: "agMultiColumnFilter" },
+  { field: "location", headerName: "Location", filter: "agMultiColumnFilter" },
+];


### PR DESCRIPTION
## Summary
- add `HospitalityHubAdminPage` with tabbed grids for categories
- create `CategoryForm` client component for CRUD operations
- add dynamic routes for creating and editing hospitality hub items
- add grid fields and link renderer for hospitality hub admin grids

## Testing
- `npm run lint` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684174a370c0832688cfd2e6700a4fe6