### PR TITLE
Add tabs to Hospitality Hub admin page

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PerygonTabs } from "../../big-up/tabs/PerygonTabs";
+import { PerygonTabs } from "../../../big-up/tabs/PerygonTabs";
 
 const categories = ["Hotels", "Rewards", "Events", "Medical", "Legal"];
 


### PR DESCRIPTION
## Summary
- add PerygonTabs UI to the hospitality hub admin client
- create a tab for each category with empty content

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_684179e76b848326983f8693963a36ea