### PR TITLE
Display items in admin Hospitality Hub tabs

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AdminCategoryItemCard.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AdminCategoryItemCard.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { VStack, Text, Image } from "@chakra-ui/react";
+import PerygonCard from "@/components/layout/PerygonCard";
+
+interface AdminCategoryItemCardProps {
+  title: string;
+  description?: string;
+  image?: string;
+}
+
+export const AdminCategoryItemCard = ({
+  title,
+  description,
+  image,
+}: AdminCategoryItemCardProps) => {
+  return (
+    <PerygonCard width="100%" height="100%" p={4} display="flex" flexDirection="column">
+      {image && <Image src={image} alt={title} borderRadius="md" mb={2} />}
+      <VStack align="start" spacing={1} flex={1}>
+        <Text fontWeight="bold">{title}</Text>
+        {description && <Text fontSize="sm">{description}</Text>}
+      </VStack>
+    </PerygonCard>
+  );
+};
+
+export default AdminCategoryItemCard;

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SimpleGrid, Spinner } from "@chakra-ui/react";
+import AdminCategoryItemCard from "./AdminCategoryItemCard";
+
+interface CategoryTabContentProps {
+  category: string;
+}
+
+export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
+  const [items, setItems] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchItems = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/hospitality-hub/${category.toLowerCase()}`);
+        const data = await res.json();
+        if (res.ok) {
+          setItems(data.resource || []);
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchItems();
+  }, [category]);
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
+      {items.map((item) => (
+        <AdminCategoryItemCard
+          key={item.id || item.name || item.provider}
+          title={item.name || item.title || item.provider}
+          description={item.description || item.speciality}
+          image={item.image}
+        />
+      ))}
+    </SimpleGrid>
+  );
+};
+
+export default CategoryTabContent;

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { PerygonTabs } from "../../../big-up/tabs/PerygonTabs";
+import CategoryTabContent from "./CategoryTabContent";
 
 const categories = ["Hotels", "Rewards", "Events", "Medical", "Legal"];
 
 export const HospitalityHubAdminClientInner = () => {
   const tabsData = categories.map((category) => ({
     header: category,
-    content: <></>,
+    content: <CategoryTabContent category={category} />,
   }));
 
   return <PerygonTabs tabs={tabsData} />;


### PR DESCRIPTION
## Summary
- load data for each Hospitality Hub category in admin
- show items in a grid inside each tab
- add simple item card used by admin tabs

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68418073ae28832687b1be9f93906544