### PR TITLE
Add hospitality types and apply them

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -3,13 +3,14 @@
 import { useEffect, useState } from "react";
 import { SimpleGrid, Spinner } from "@chakra-ui/react";
 import AdminCategoryItemCard from "./AdminCategoryItemCard";
+import { HospitalityItem } from "@/types/hospitality";
 
 interface CategoryTabContentProps {
   category: string;
 }
 
 export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
-  const [items, setItems] = useState<any[]>([]);
+  const [items, setItems] = useState<HospitalityItem[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -9,6 +9,7 @@ import {
   Center,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import { HospitalityItem } from "@/types/hospitality";
 import CategoryItemCard from "./CategoryItemCard";
 import ItemDetailModal from "./ItemDetailModal";
 
@@ -27,11 +28,11 @@ const cards: HubCard[] = [
 
 export function HospitalityHubMasonry() {
   const [selected, setSelected] = useState<string | null>(null);
-  const [items, setItems] = useState<any[]>([]);
+  const [items, setItems] = useState<HospitalityItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
-  const [selectedItem, setSelectedItem] = useState<any | null>(null);
+  const [selectedItem, setSelectedItem] = useState<HospitalityItem | null>(null);
 
   const handleItemClick = async (itemId: string) => {
     if (!selected) return;

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -11,11 +11,12 @@ import {
   Spinner,
   VStack,
 } from "@chakra-ui/react";
+import { HospitalityItem } from "@/types/hospitality";
 
 interface ItemDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
-  item?: any;
+  item?: HospitalityItem;
   loading?: boolean;
 }
 

--- a/src/app/api/hospitality-hub/mockData/events.ts
+++ b/src/app/api/hospitality-hub/mockData/events.ts
@@ -1,4 +1,6 @@
-export const events = [
+import { Event } from "@/types/hospitality";
+
+export const events: Event[] = [
   {
     id: "event-1",
     name: "Wine Tasting Evening",

--- a/src/app/api/hospitality-hub/mockData/hotels.ts
+++ b/src/app/api/hospitality-hub/mockData/hotels.ts
@@ -1,4 +1,6 @@
-export const hotels = [
+import { Hotel } from "@/types/hospitality";
+
+export const hotels: Hotel[] = [
   {
     id: "hotel-1",
     name: "Grand Plaza",

--- a/src/app/api/hospitality-hub/mockData/legal.ts
+++ b/src/app/api/hospitality-hub/mockData/legal.ts
@@ -1,4 +1,6 @@
-export const legal = [
+import { LegalProvider } from "@/types/hospitality";
+
+export const legal: LegalProvider[] = [
   {
     id: "legal-1",
     provider: "City Law Firm",

--- a/src/app/api/hospitality-hub/mockData/medical.ts
+++ b/src/app/api/hospitality-hub/mockData/medical.ts
@@ -1,4 +1,6 @@
-export const medical = [
+import { MedicalProvider } from "@/types/hospitality";
+
+export const medical: MedicalProvider[] = [
   {
     id: "medical-1",
     provider: "City Clinic",

--- a/src/app/api/hospitality-hub/mockData/rewards.ts
+++ b/src/app/api/hospitality-hub/mockData/rewards.ts
@@ -1,4 +1,6 @@
-export const rewards = [
+import { Reward } from "@/types/hospitality";
+
+export const rewards: Reward[] = [
   {
     id: "reward-1",
     name: "Free Breakfast",

--- a/src/types/hospitality.ts
+++ b/src/types/hospitality.ts
@@ -1,0 +1,51 @@
+export interface Hotel {
+  id: string;
+  name: string;
+  location: string;
+  rating: number;
+  description: string;
+  image: string;
+}
+
+export interface Event {
+  id: string;
+  name: string;
+  date: string;
+  location: string;
+  description: string;
+  image: string;
+}
+
+export interface Reward {
+  id: string;
+  name: string;
+  points: number;
+  description: string;
+  expiryDate: string;
+  image: string;
+}
+
+export interface MedicalProvider {
+  id: string;
+  provider: string;
+  speciality: string;
+  location: string;
+  contact: string;
+  image: string;
+}
+
+export interface LegalProvider {
+  id: string;
+  provider: string;
+  speciality: string;
+  location: string;
+  contact: string;
+  image: string;
+}
+
+export type HospitalityItem =
+  | Hotel
+  | Event
+  | Reward
+  | MedicalProvider
+  | LegalProvider;


### PR DESCRIPTION
## Summary
- add `src/types/hospitality.ts` with interfaces for Hotel, Event, Reward, MedicalProvider and LegalProvider
- update hospitality hub components to use the new types instead of `any`
- apply the interfaces to the hospitality-hub mock data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684184a1225c8326a5963526cc0c0f20