### PR TITLE
Add hospitality hub types and config

### DIFF
--- a/src/lib/hospitalityHubConfig.ts
+++ b/src/lib/hospitalityHubConfig.ts
@@ -1,0 +1,36 @@
+import { HospitalityCategory } from "@/types/hospitalityHub";
+
+export const hospitalityHubCategories: HospitalityCategory[] = [
+  {
+    key: "hotels",
+    displayName: "Hotels",
+    image: "/big-up/big-up-app-bg.webp",
+    optionalFields: ["location"],
+  },
+  {
+    key: "rewards",
+    displayName: "Rewards",
+    image: "/carousel/enps-carousel-bg.webp",
+    optionalFields: [],
+  },
+  {
+    key: "events",
+    displayName: "Events",
+    image: "/carousel/happiness-score-carousel-bg.webp",
+    optionalFields: ["location", "date"],
+  },
+  {
+    key: "medical",
+    displayName: "Medical",
+    image: "/carousel/business-score-carousel-bg.webp",
+    optionalFields: ["location"],
+  },
+  {
+    key: "legal",
+    displayName: "Legal",
+    image: "/carousel/client-satisfaction-bg.webp",
+    optionalFields: ["location"],
+  },
+];
+
+export default hospitalityHubCategories;

--- a/src/types/hospitalityHub.ts
+++ b/src/types/hospitalityHub.ts
@@ -1,0 +1,15 @@
+export interface HospitalityItem {
+  id: string;
+  title: string;
+  description: string;
+  location?: string;
+  date?: string;
+  [key: string]: any;
+}
+
+export interface HospitalityCategory {
+  key: string;
+  displayName: string;
+  image: string;
+  optionalFields: Array<"location" | "date">;
+}


### PR DESCRIPTION
## Summary
- define `HospitalityItem` and `HospitalityCategory` interfaces
- configure categories with images and optional fields

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684193509cbc83269f791a411e79d14b