### PR TITLE
Add dynamic Hospitality Hub config

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryConfigForm.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryConfigForm.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControl,
+  FormLabel,
+  Input,
+  VStack,
+} from "@chakra-ui/react";
+
+interface Props {
+  onAdd: () => void;
+}
+
+export default function CategoryConfigForm({ onAdd }: Props) {
+  const [key, setKey] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [image, setImage] = useState("");
+  const [location, setLocation] = useState(false);
+  const [date, setDate] = useState(false);
+
+  const handleSubmit = async () => {
+    await fetch("/api/hospitality-hub/config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        key,
+        displayName,
+        image,
+        optionalFields: { location, date },
+      }),
+    });
+    setKey("");
+    setDisplayName("");
+    setImage("");
+    setLocation(false);
+    setDate(false);
+    onAdd();
+  };
+
+  return (
+    <Box p={4} borderWidth="1px" borderRadius="md" mb={4}>
+      <VStack spacing={3} align="stretch">
+        <FormControl>
+          <FormLabel>Key</FormLabel>
+          <Input value={key} onChange={(e) => setKey(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Display Name</FormLabel>
+          <Input
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Image</FormLabel>
+          <Input value={image} onChange={(e) => setImage(e.target.value)} />
+        </FormControl>
+        <Checkbox
+          isChecked={location}
+          onChange={(e) => setLocation(e.target.checked)}
+        >
+          Has Location
+        </Checkbox>
+        <Checkbox isChecked={date} onChange={(e) => setDate(e.target.checked)}>
+          Has Date
+        </Checkbox>
+        <Button onClick={handleSubmit} colorScheme="pink">
+          Add Category
+        </Button>
+      </VStack>
+    </Box>
+  );
+}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState } from "react";
 import { SimpleGrid, Spinner } from "@chakra-ui/react";
 import ItemCard from "../../components/ItemCard";
+import type { HospitalityHubCategory } from "../../hospitalityHubConfig";
 
 interface CategoryTabContentProps {
-  category: string;
+  category: HospitalityHubCategory;
 }
 
 export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
@@ -16,7 +17,7 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
     const fetchItems = async () => {
       setLoading(true);
       try {
-        const res = await fetch(`/api/hospitality-hub/${category.toLowerCase()}`);
+        const res = await fetch(`/api/hospitality-hub/${category.key}`);
         const data = await res.json();
         if (res.ok) {
           setItems(data.resource || []);

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,15 +1,34 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { PerygonTabs } from "../../../big-up/tabs/PerygonTabs";
 import CategoryTabContent from "./CategoryTabContent";
-
-const categories = ["Hotels", "Rewards", "Events", "Medical", "Legal"];
+import CategoryConfigForm from "./CategoryConfigForm";
+import type { HospitalityHubCategory } from "../../hospitalityHubConfig";
 
 export const HospitalityHubAdminClientInner = () => {
-  const tabsData = categories.map((category) => ({
-    header: category,
-    content: <CategoryTabContent category={category} />,
-  }));
+  const [categories, setCategories] = useState<HospitalityHubCategory[]>([]);
+
+  const fetchCategories = async () => {
+    const res = await fetch("/api/hospitality-hub/config");
+    const data = await res.json();
+    setCategories(data);
+  };
+
+  useEffect(() => {
+    fetchCategories();
+  }, []);
+
+  const tabsData = [
+    {
+      header: "Config",
+      content: <CategoryConfigForm onAdd={fetchCategories} />,
+    },
+    ...categories.map((category) => ({
+      header: category.displayName,
+      content: <CategoryTabContent category={category} />,
+    })),
+  ];
 
   return <PerygonTabs tabs={tabsData} />;
 };

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -11,27 +11,27 @@ import {
 import { useEffect, useState } from "react";
 import ItemCard from "../../components/ItemCard";
 import ItemDetailModal from "./ItemDetailModal";
+import type { HospitalityHubCategory } from "../../hospitalityHubConfig";
 
-interface HubCard {
-  title: string;
-  image: string;
-}
-
-const cards: HubCard[] = [
-  { title: "Hotels", image: "/big-up/big-up-app-bg.webp" },
-  { title: "Rewards", image: "/carousel/enps-carousel-bg.webp" },
-  { title: "Events", image: "/carousel/happiness-score-carousel-bg.webp" },
-  { title: "Medical", image: "/carousel/business-score-carousel-bg.webp" },
-  { title: "Legal", image: "/carousel/client-satisfaction-bg.webp" },
-];
+interface HubCard extends HospitalityHubCategory {}
 
 export function HospitalityHubMasonry() {
-  const [selected, setSelected] = useState<string | null>(null);
+  const [categories, setCategories] = useState<HubCard[]>([]);
+  const [selected, setSelected] = useState<HubCard | null>(null);
   const [items, setItems] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
   const [selectedItem, setSelectedItem] = useState<any | null>(null);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      const res = await fetch("/api/hospitality-hub/config");
+      const data = await res.json();
+      setCategories(data);
+    };
+    fetchCategories();
+  }, []);
 
   const handleItemClick = async (itemId: string) => {
     if (!selected) return;
@@ -39,7 +39,7 @@ export function HospitalityHubMasonry() {
     setModalLoading(true);
     try {
       const res = await fetch(
-        `/api/hospitality-hub/${selected.toLowerCase()}/${itemId}`
+        `/api/hospitality-hub/${selected.key}/${itemId}`
       );
       const data = await res.json();
       if (res.ok) {
@@ -58,7 +58,7 @@ export function HospitalityHubMasonry() {
       setLoading(true);
       try {
         const res = await fetch(
-          `/api/hospitality-hub/${selected.toLowerCase()}`
+          `/api/hospitality-hub/${selected.key}`
         );
         const data = await res.json();
         if (res.ok) {
@@ -117,20 +117,20 @@ export function HospitalityHubMasonry() {
 
   return (
     <SimpleGrid columns={[2, 3, 5]} gap={4} w="100%">
-      {cards.map((card) => (
+      {categories.map((card) => (
         <Box
-          key={card.title}
+          key={card.key}
           position="relative"
           h="700px"
           borderRadius="lg"
           overflow="hidden"
           role="group"
           cursor="pointer"
-          onClick={() => setSelected(card.title)}
+          onClick={() => setSelected(card)}
         >
           <Image
             src={card.image}
-            alt={card.title}
+            alt={card.displayName}
             objectFit="cover"
             w="100%"
             h="100%"
@@ -150,7 +150,7 @@ export function HospitalityHubMasonry() {
             _groupHover={{ opacity: 1 }}
           >
             <Text color="white" fontWeight="bold" fontSize="xl">
-              {card.title}
+              {card.displayName}
             </Text>
           </Box>
         </Box>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hospitalityHubConfig.json
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hospitalityHubConfig.json
@@ -1,0 +1,32 @@
+[
+  {
+    "key": "hotels",
+    "displayName": "Hotels",
+    "image": "/big-up/big-up-app-bg.webp",
+    "optionalFields": { "location": true, "date": false }
+  },
+  {
+    "key": "rewards",
+    "displayName": "Rewards",
+    "image": "/carousel/enps-carousel-bg.webp",
+    "optionalFields": { "location": false, "date": false }
+  },
+  {
+    "key": "events",
+    "displayName": "Events",
+    "image": "/carousel/happiness-score-carousel-bg.webp",
+    "optionalFields": { "location": true, "date": true }
+  },
+  {
+    "key": "medical",
+    "displayName": "Medical",
+    "image": "/carousel/business-score-carousel-bg.webp",
+    "optionalFields": { "location": true, "date": false }
+  },
+  {
+    "key": "legal",
+    "displayName": "Legal",
+    "image": "/carousel/client-satisfaction-bg.webp",
+    "optionalFields": { "location": true, "date": false }
+  }
+]

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hospitalityHubConfig.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hospitalityHubConfig.ts
@@ -1,0 +1,13 @@
+export type HospitalityHubCategory = {
+  key: string;
+  displayName: string;
+  image: string;
+  optionalFields?: {
+    location?: boolean;
+    date?: boolean;
+  };
+};
+
+import config from './hospitalityHubConfig.json';
+
+export default config as HospitalityHubCategory[];

--- a/src/app/api/hospitality-hub/config/route.ts
+++ b/src/app/api/hospitality-hub/config/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const configPath = path.join(
+  process.cwd(),
+  'src',
+  'app',
+  '(site)',
+  '(apps-non-standard)',
+  'hospitality-hub',
+  'hospitalityHubConfig.json'
+);
+
+export async function GET() {
+  try {
+    const data = await fs.readFile(configPath, 'utf-8');
+    return NextResponse.json(JSON.parse(data));
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const newCategory = await req.json();
+    const data = await fs.readFile(configPath, 'utf-8');
+    const config = JSON.parse(data);
+    config.push(newCategory);
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2));
+    return NextResponse.json({ message: 'Category added' });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add HospitalityHubConfig JSON and TS exports
- expose new `/api/hospitality-hub/config` route to read/write config
- implement CategoryConfigForm for admin
- load categories from config in admin and user UIs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841935ed2ec83268549837bd8673f77