### PR TITLE
Add category CRUD API and modal

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+} from "@chakra-ui/react";
+import { useForm } from "react-hook-form";
+
+interface AddCategoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+interface FormValues {
+  title: string;
+  description: string;
+}
+
+export default function AddCategoryModal({
+  isOpen,
+  onClose,
+  onCreated,
+}: AddCategoryModalProps) {
+  const { register, handleSubmit, reset } = useForm<FormValues>();
+
+  const onSubmit = async (data: FormValues) => {
+    await fetch("/api/hospitality-hub/categories", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+    onCreated();
+    reset();
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Create Category</ModalHeader>
+        <ModalCloseButton />
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <ModalBody>
+            <FormControl mb={4} isRequired>
+              <FormLabel>Title</FormLabel>
+              <Input {...register("title", { required: true })} />
+            </FormControl>
+            <FormControl mb={4} isRequired>
+              <FormLabel>Description</FormLabel>
+              <Input {...register("description", { required: true })} />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button type="submit" colorScheme="blue">
+              Create
+            </Button>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,14 +1,31 @@
 "use client";
 
+import { useState } from "react";
+import { Button, VStack } from "@chakra-ui/react";
 import { PerygonTabs } from "../../../big-up/tabs/PerygonTabs";
 import hospitalityHubConfig from "../../hospitalityHubConfig";
 import CategoryTabContent from "./CategoryTabContent";
+import AddCategoryModal from "./AddCategoryModal";
 
 export const HospitalityHubAdminClientInner = () => {
+  const [modalOpen, setModalOpen] = useState(false);
+
   const tabsData = hospitalityHubConfig.map((category) => ({
     header: category.title,
     content: <CategoryTabContent category={category} />,
   }));
 
-  return <PerygonTabs tabs={tabsData} />;
+  return (
+    <VStack w="100%" spacing={4} align="stretch">
+      <Button alignSelf="flex-end" onClick={() => setModalOpen(true)}>
+        Add Category
+      </Button>
+      <PerygonTabs tabs={tabsData} />
+      <AddCategoryModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onCreated={() => {}}
+      />
+    </VStack>
+  );
 };

--- a/src/app/api/hospitality-hub/categories/route.ts
+++ b/src/app/api/hospitality-hub/categories/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { categories } from '../mockData/categories';
+
+let categoriesData = [...categories];
+
+export async function GET() {
+  return NextResponse.json({ resource: categoriesData });
+}
+
+export async function POST(req: NextRequest) {
+  const payload = await req.json();
+  const newCategory = {
+    id: `cat-${Date.now()}`,
+    title: payload.title,
+    description: payload.description,
+  };
+  categoriesData.push(newCategory);
+  return NextResponse.json({ resource: newCategory });
+}
+
+export async function PUT(req: NextRequest) {
+  const payload = await req.json();
+  const index = categoriesData.findIndex((c) => c.id === payload.id);
+  if (index === -1) {
+    return NextResponse.json({ error: 'Category not found' }, { status: 404 });
+  }
+  categoriesData[index] = { ...categoriesData[index], ...payload };
+  return NextResponse.json({ resource: categoriesData[index] });
+}
+
+export async function DELETE(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get('id');
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+  }
+  const index = categoriesData.findIndex((c) => c.id === id);
+  if (index === -1) {
+    return NextResponse.json({ error: 'Category not found' }, { status: 404 });
+  }
+  const deleted = categoriesData.splice(index, 1)[0];
+  return NextResponse.json({ resource: deleted });
+}

--- a/src/app/api/hospitality-hub/mockData/categories.ts
+++ b/src/app/api/hospitality-hub/mockData/categories.ts
@@ -1,0 +1,4 @@
+export const categories = [
+  { id: "cat-1", title: "Dining", description: "Restaurants and cafes" },
+  { id: "cat-2", title: "Tours", description: "Guided tours and activities" },
+];

--- a/src/app/api/hospitality-hub/mockData/index.ts
+++ b/src/app/api/hospitality-hub/mockData/index.ts
@@ -3,6 +3,7 @@ import { hotels } from './hotels';
 import { legal } from './legal';
 import { medical } from './medical';
 import { rewards } from './rewards';
+import { categories } from './categories';
 
 export const mockDataMap: Record<string, any[]> = {
   events,
@@ -10,4 +11,5 @@ export const mockDataMap: Record<string, any[]> = {
   legal,
   medical,
   rewards,
+  categories,
 };


### PR DESCRIPTION
## Summary
- add in-memory categories list for hospitality hub
- expose CRUD API for categories
- add modal and button for creating categories in Hospitality Hub admin

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684198fbf234832680c101ec95f849db