### PR TITLE
Update admin panel categories fetch

### DIFF
--- a/src/app/api/hospitality-hub/tabCategories/route.ts
+++ b/src/app/api/hospitality-hub/tabCategories/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import hospitalityHubConfig from '@/app/(site)/(apps-non-standard)/hospitality-hub/hospitalityHubConfig';
+
+export async function GET() {
+  return NextResponse.json({ resource: hospitalityHubConfig });
+}


### PR DESCRIPTION
## Summary
- add API route to provide hospitality hub tab categories
- fetch categories in HospitalityHubAdminClientInner
- reload categories when a new category is added

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` *(fails: `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_68419b4f775c8326828925e4ce56bc40