### PR TITLE
Improve Hospitality Hub fetch logic

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -1,39 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { SimpleGrid, Spinner } from "@chakra-ui/react";
 import HospitalityItemCard from "../../components/HospitalityItemCard";
-import {
-  HospitalityCategory,
-  HospitalityItem,
-} from "../../hospitalityHubConfig";
+import { HospitalityCategory } from "../../hospitalityHubConfig";
+import useHospitalityItems from "../../hooks/useHospitalityItems";
 
 interface CategoryTabContentProps {
   category: HospitalityCategory;
 }
 
 export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
-  const [items, setItems] = useState<HospitalityItem[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchItems = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/hospitality-hub/${category.key}`);
-        const data = await res.json();
-        if (res.ok) {
-          setItems(data.resource || []);
-        }
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchItems();
-  }, [category]);
+  const { items, loading } = useHospitalityItems(category.key);
 
   if (loading) {
     return <Spinner />;

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -8,18 +8,18 @@ import {
   Spinner,
   Center,
 } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import HospitalityItemCard from "../../components/HospitalityItemCard";
 import ItemDetailModal from "./ItemDetailModal";
 import hospitalityHubConfig, {
   HospitalityItem,
 } from "../../hospitalityHubConfig";
+import useHospitalityItems from "../../hooks/useHospitalityItems";
 // import hospitalityHubConfig, { HospitalityItem } from "../hospitalityHubConfig";
 
 export function HospitalityHubMasonry() {
   const [selected, setSelected] = useState<string | null>(null);
-  const [items, setItems] = useState<HospitalityItem[]>([]);
-  const [loading, setLoading] = useState(false);
+  const { items, loading } = useHospitalityItems(selected);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
   const [selectedItem, setSelectedItem] = useState<HospitalityItem | null>(
@@ -43,24 +43,7 @@ export function HospitalityHubMasonry() {
     }
   };
 
-  useEffect(() => {
-    if (!selected) return;
-    const fetchItems = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/hospitality-hub/${selected}`);
-        const data = await res.json();
-        if (res.ok) {
-          setItems(data.resource || []);
-        }
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchItems();
-  }, [selected]);
+  // Items are fetched via useHospitalityItems when a category is selected
 
   if (selected) {
     if (loading) {
@@ -74,7 +57,6 @@ export function HospitalityHubMasonry() {
           cursor="pointer"
           onClick={() => {
             setSelected(null);
-            setItems([]);
           }}
         >
           <Text fontWeight="bold">&larr; Back</Text>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+import { HospitalityItem } from '../hospitalityHubConfig';
+
+export function useHospitalityItems(categoryKey?: string | null) {
+  const [items, setItems] = useState<HospitalityItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!categoryKey) return;
+
+    const fetchItems = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/hospitality-hub/${categoryKey}`);
+        const data = await res.json();
+        if (res.ok) {
+          setItems(data.resource || []);
+        } else {
+          throw new Error(data?.error || 'Failed to fetch items');
+        }
+      } catch (err: any) {
+        console.error(err);
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchItems();
+  }, [categoryKey]);
+
+  return { items, loading, error };
+}
+
+export default useHospitalityItems;


### PR DESCRIPTION
## Summary
- centralize item fetching in hospitality hub with `useHospitalityItems`
- refactor `CategoryTabContent` and `HospitalityHubMasonry` to use the new hook

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841cbda4930832684c08e7092be4e0d