### PR TITLE
Refactor Hospitality Hub data fetching

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { SimpleGrid, Spinner } from "@chakra-ui/react";
+import useHospitalityItems from "../../hooks/useHospitalityItems";
 import HospitalityItemCard from "../../components/HospitalityItemCard";
 import {
   HospitalityCategory,
-  HospitalityItem,
 } from "../../hospitalityHubConfig";
 
 interface CategoryTabContentProps {
@@ -13,27 +12,7 @@ interface CategoryTabContentProps {
 }
 
 export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
-  const [items, setItems] = useState<HospitalityItem[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchItems = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/hospitality-hub/${category.key}`);
-        const data = await res.json();
-        if (res.ok) {
-          setItems(data.resource || []);
-        }
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchItems();
-  }, [category]);
+  const { items, loading } = useHospitalityItems(category.key);
 
   if (loading) {
     return <Spinner />;

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -8,18 +8,18 @@ import {
   Spinner,
   Center,
 } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import HospitalityItemCard from "../../components/HospitalityItemCard";
 import ItemDetailModal from "./ItemDetailModal";
 import hospitalityHubConfig, {
   HospitalityItem,
 } from "../../hospitalityHubConfig";
+import useHospitalityItems from "../../hooks/useHospitalityItems";
 // import hospitalityHubConfig, { HospitalityItem } from "../hospitalityHubConfig";
 
 export function HospitalityHubMasonry() {
   const [selected, setSelected] = useState<string | null>(null);
-  const [items, setItems] = useState<HospitalityItem[]>([]);
-  const [loading, setLoading] = useState(false);
+  const { items, loading } = useHospitalityItems(selected);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
   const [selectedItem, setSelectedItem] = useState<HospitalityItem | null>(
@@ -43,24 +43,6 @@ export function HospitalityHubMasonry() {
     }
   };
 
-  useEffect(() => {
-    if (!selected) return;
-    const fetchItems = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/hospitality-hub/${selected}`);
-        const data = await res.json();
-        if (res.ok) {
-          setItems(data.resource || []);
-        }
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchItems();
-  }, [selected]);
 
   if (selected) {
     if (loading) {
@@ -74,7 +56,6 @@ export function HospitalityHubMasonry() {
           cursor="pointer"
           onClick={() => {
             setSelected(null);
-            setItems([]);
           }}
         >
           <Text fontWeight="bold">&larr; Back</Text>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { HospitalityItem } from '../hospitalityHubConfig';
+
+export const useHospitalityItems = (category: string | null) => {
+  const [items, setItems] = useState<HospitalityItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!category) {
+      setItems([]);
+      return;
+    }
+
+    const fetchItems = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/hospitality-hub/${category}`);
+        const data = await res.json();
+        if (res.ok) {
+          setItems(data.resource || []);
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchItems();
+  }, [category]);
+
+  return { items, loading };
+};
+
+export default useHospitalityItems;


### PR DESCRIPTION
## Summary
- add `useHospitalityItems` hook
- refactor `CategoryTabContent` and `HospitalityHubMasonry` to use new hook

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cc3c61a0832699dd6f3600320470