### PR TITLE
Fetch categories for hospitality hub on page load

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -16,9 +16,18 @@ import useHospitalityItems from "../../hooks/useHospitalityItems";
 import useHospitalityCategories from "../../hooks/useHospitalityCategories";
 // import hospitalityHubConfig, { HospitalityItem } from "../hospitalityHubConfig";
 
-export function HospitalityHubMasonry() {
+import { HospitalityCategory } from "@/types/hospitalityHub";
+
+interface HospitalityHubMasonryProps {
+  initialCategories?: HospitalityCategory[];
+}
+
+export function HospitalityHubMasonry({
+  initialCategories = [],
+}: HospitalityHubMasonryProps) {
   const [selected, setSelected] = useState<string | null>(null);
-  const { categories, loading: categoriesLoading } = useHospitalityCategories();
+  const { categories, loading: categoriesLoading } =
+    useHospitalityCategories(initialCategories);
   const { items, loading } = useHospitalityItems(selected);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
@@ -1,10 +1,28 @@
 import { Center } from "@chakra-ui/react";
 import { HospitalityHubMasonry } from "./components/HospitalityHubMasonry";
+import apiClient from "@/lib/apiClient";
+import { HospitalityCategory } from "@/types/hospitalityHub";
 
-export default function HospitalityHubPage() {
+export const dynamic = "force-dynamic";
+
+export default async function HospitalityHubPage() {
+  let initialCategories: HospitalityCategory[] = [];
+  try {
+    const res = await apiClient("/userHospitalityCategory/allBy", {
+      method: "GET",
+      cache: "no-store",
+    });
+    const data = await res.json();
+    if (res.ok) {
+      initialCategories = data.resource || [];
+    }
+  } catch (err) {
+    console.error("Failed to fetch categories", err);
+  }
+
   return (
     <Center minH="100vh" w="100%" p={4}>
-      <HospitalityHubMasonry />
+      <HospitalityHubMasonry initialCategories={initialCategories} />
     </Center>
   );
 }

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityCategories.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityCategories.ts
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react';
-import { HospitalityCategory } from '@/types/hospitalityHub';
+import { useState, useEffect } from "react";
+import { HospitalityCategory } from "@/types/hospitalityHub";
 
-export function useHospitalityCategories() {
-  const [categories, setCategories] = useState<HospitalityCategory[]>([]);
+export function useHospitalityCategories(initialCategories: HospitalityCategory[] = []) {
+  const [categories, setCategories] = useState<HospitalityCategory[]>(initialCategories);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 


### PR DESCRIPTION
## Summary
- ensure categories are fetched server-side for Hospitality Hub page
- allow HospitalityHubMasonry to accept initial categories
- allow useHospitalityCategories to take initial data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846bfb2bca08326aa36cfb868071543