### PR TITLE
Fix hospitality hub category addition

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -23,7 +23,7 @@ interface AddCategoryModalProps {
 }
 
 interface FormValues {
-  title: string;
+  name: string;
   description: string;
 }
 
@@ -62,8 +62,8 @@ export default function AddCategoryModal({
         <form onSubmit={handleSubmit(onSubmit)}>
           <ModalBody>
             <FormControl mb={4} isRequired>
-              <FormLabel>Title</FormLabel>
-              <Input {...register("title", { required: true })} />
+              <FormLabel>Name</FormLabel>
+              <Input {...register("name", { required: true })} />
             </FormControl>
             <FormControl mb={4} isRequired>
               <FormLabel>Description</FormLabel>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -118,7 +118,7 @@ export function HospitalityHubMasonry({
         >
           <Image
             src={category.image}
-            alt={category.title}
+            alt={category.name}
             objectFit="cover"
             w="100%"
             h="100%"
@@ -138,7 +138,7 @@ export function HospitalityHubMasonry({
             _groupHover={{ opacity: 1 }}
           >
             <Text color="white" fontWeight="bold" fontSize="xl">
-              {category.title}
+              {category.name}
             </Text>
           </Box>
         </Box>


### PR DESCRIPTION
## Summary
- rename category field `title` to `name`
- show category `name` in hospitality hub masonry

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca64614883269358452471ed0e3c