### PR TITLE
Add dropdown for categories in admin

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,29 +1,51 @@
 "use client";
 
-import { useState } from "react";
-import { Button, VStack, Spinner } from "@chakra-ui/react";
-import { PerygonTabs } from "../../../big-up/tabs/PerygonTabs";
+import { useEffect, useState } from "react";
+import { Button, VStack, Spinner, Select } from "@chakra-ui/react";
 import { HospitalityCategory } from "@/types/hospitalityHub";
 import useHospitalityCategories from "../../hooks/useHospitalityCategories";
 import CategoryTabContent from "./CategoryTabContent";
 import AddCategoryModal from "./AddCategoryModal";
-import { useUser } from "@/providers/UserProvider";
 
 export const HospitalityHubAdminClientInner = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const { categories, loading, refresh } = useHospitalityCategories();
+  const [selectedCategory, setSelectedCategory] = useState<HospitalityCategory | null>(null);
 
-  const tabsData = categories.map((category) => ({
-    header: category.name,
-    content: <CategoryTabContent category={category} />,
-  }));
+  useEffect(() => {
+    if (!selectedCategory && categories.length > 0) {
+      setSelectedCategory(categories[0]);
+    }
+  }, [categories, selectedCategory]);
 
   return (
     <VStack w="100%" spacing={4} align="stretch">
       <Button alignSelf="flex-end" onClick={() => setModalOpen(true)}>
         Add Category
       </Button>
-      {loading ? <Spinner /> : <PerygonTabs tabs={tabsData} />}
+      {loading ? (
+        <Spinner />
+      ) : (
+        <>
+          <Select
+            value={selectedCategory?.id || ""}
+            onChange={(e) => {
+              const cat = categories.find((c) => c.id === e.target.value);
+              setSelectedCategory(cat || null);
+            }}
+            color="primaryTextColor"
+            bg="elementBG"
+            sx={{ option: { backgroundColor: "var(--chakra-colors-elementBG)" } }}
+          >
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </Select>
+          {selectedCategory && <CategoryTabContent category={selectedCategory} />}
+        </>
+      )}
       <AddCategoryModal
         isOpen={modalOpen}
         onClose={() => setModalOpen(false)}


### PR DESCRIPTION
## Summary
- swap admin category tabs for a dropdown selector

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cb0a5bec8326ab52703e6e6c549f