### PR TITLE
Add item creation to Hospitality Hub admin

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useUser } from "@/providers/UserProvider";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+} from "@chakra-ui/react";
+import { useForm } from "react-hook-form";
+
+interface AddItemModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  categoryId: string;
+  onCreated: () => void;
+}
+
+interface FormValues {
+  title: string;
+  description: string;
+}
+
+export default function AddItemModal({
+  isOpen,
+  onClose,
+  categoryId,
+  onCreated,
+}: AddItemModalProps) {
+  const { register, handleSubmit, reset } = useForm<FormValues>();
+
+  const { user } = useUser();
+
+  const customerId = user?.customerId;
+  const userId = user?.userId;
+
+  const onSubmit = async (data: FormValues) => {
+    await fetch("/api/hospitality-hub/items", {
+      method: "POST",
+      body: JSON.stringify({
+        ...data,
+        customerId,
+        userId,
+        categoryId,
+      }),
+    });
+    onCreated();
+    reset();
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Create Item</ModalHeader>
+        <ModalCloseButton />
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <ModalBody>
+            <FormControl mb={4} isRequired>
+              <FormLabel>Title</FormLabel>
+              <Input {...register("title", { required: true })} />
+            </FormControl>
+            <FormControl mb={4} isRequired>
+              <FormLabel>Description</FormLabel>
+              <Input {...register("description", { required: true })} />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button type="submit" colorScheme="blue">
+              Create
+            </Button>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -1,31 +1,49 @@
 "use client";
 
-import { SimpleGrid, Spinner } from "@chakra-ui/react";
+import { SimpleGrid, Spinner, VStack, Button } from "@chakra-ui/react";
 import HospitalityItemCard from "../../components/HospitalityItemCard";
 import { HospitalityCategory } from "@/types/hospitalityHub";
 import useHospitalityItems from "../../hooks/useHospitalityItems";
+import { useState } from "react";
+import AddItemModal from "./AddItemModal";
 
 interface CategoryTabContentProps {
   category: HospitalityCategory;
 }
 
 export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
-  const { items, loading } = useHospitalityItems(category.id);
+  const { items, loading, refresh } = useHospitalityItems(category.id);
+  const [modalOpen, setModalOpen] = useState(false);
 
   if (loading) {
     return <Spinner />;
   }
 
   return (
-    <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
-      {items.map((item) => (
-        <HospitalityItemCard
-          key={item.id}
-          item={item}
-          optionalFields={category.optionalFields || []}
-        />
-      ))}
-    </SimpleGrid>
+    <VStack w="100%" align="stretch" spacing={4}>
+      <Button alignSelf="flex-end" onClick={() => setModalOpen(true)}>
+        Add Item
+      </Button>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
+          {items.map((item) => (
+            <HospitalityItemCard
+              key={item.id}
+              item={item}
+              optionalFields={category.optionalFields || []}
+            />
+          ))}
+        </SimpleGrid>
+      )}
+      <AddItemModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onCreated={refresh}
+        categoryId={category.id}
+      />
+    </VStack>
   );
 };
 

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
@@ -6,31 +6,31 @@ export function useHospitalityItems(categoryKey?: string | null) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
+  const fetchItems = async () => {
     if (!categoryKey) return;
-
-    const fetchItems = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/hospitality-hub/${categoryKey}`);
-        const data = await res.json();
-        if (res.ok) {
-          setItems(data.resource || []);
-        } else {
-          throw new Error(data?.error || 'Failed to fetch items');
-        }
-      } catch (err: any) {
-        console.error(err);
-        setError(err);
-      } finally {
-        setLoading(false);
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/hospitality-hub/items?categoryId=${categoryKey}`);
+      const data = await res.json();
+      if (res.ok) {
+        setItems(data.resource || []);
+      } else {
+        throw new Error(data?.error || 'Failed to fetch items');
       }
-    };
+    } catch (err: any) {
+      console.error(err);
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  useEffect(() => {
     fetchItems();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [categoryKey]);
 
-  return { items, loading, error };
+  return { items, loading, error, refresh: fetchItems };
 }
 
 export default useHospitalityItems;

--- a/src/types/hospitalityHub.ts
+++ b/src/types/hospitalityHub.ts
@@ -1,13 +1,21 @@
 export interface HospitalityItem {
   id: string;
-  title: string;
+  name: string;
   description: string;
-  location?: string;
-  date?: string;
-  image?: string;
-  [key: string]: any;
+  howToDetails: string;
+  extraDetails: string;
+  customerId: string;
+  itemOwnerUserId: string;
+  hospitalityCatId: string;
+  isActive: boolean;
+  startDate: string;
+  endDate: string;
+  location: string;
+  itemType: string;
+  logoImageUrl: string;
+  coverImageUrl: string;
+  additionalImageUrlList: string[];
 }
-/// above needs updateing to actual structure
 
 export interface HospitalityCategory {
   id: string;


### PR DESCRIPTION
## Summary
- enable fetching hospitality items with a refresh function
- allow adding items to a category via a new modal
- show "Add Item" button on admin page categories

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test`
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f014f2f08326bc5731513ed1365b