### PR TITLE
Enable image upload for hospitality hub items

### DIFF
--- a/src/app/api/hospitality-hub/uploadImage/route.ts
+++ b/src/app/api/hospitality-hub/uploadImage/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const file = formData.get("imageUrl");
+
+  if (!file || !(file instanceof Blob)) {
+    return NextResponse.json({ error: "No file uploaded." }, { status: 400 });
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const uploadDir = join(process.cwd(), "public", "uploads", "hospitality");
+  await mkdir(uploadDir, { recursive: true });
+  const filename = `${Date.now()}-${(file as File).name}`;
+  await writeFile(join(uploadDir, filename), buffer);
+
+  return NextResponse.json({ imageUrl: `/uploads/hospitality/${filename}` });
+}

--- a/src/hooks/useMediaUploader.ts
+++ b/src/hooks/useMediaUploader.ts
@@ -73,7 +73,7 @@ export const useMediaUploader = (
       const resp = await fetch(endpoint, { method: "POST", body: formData });
       if (!resp.ok) throw new Error("Failed to upload file");
 
-      await resp.json();
+      const data = await resp.json();
       toast({
         title: "Upload successful",
         description: "Your file has been uploaded.",
@@ -83,6 +83,7 @@ export const useMediaUploader = (
         position: "bottom-right",
       });
       onSuccess();
+      return data;
     } catch (err) {
       console.error("File upload error:", err);
       toast({


### PR DESCRIPTION
## Summary
- return upload data from `useMediaUploader`
- add API route for storing uploaded images
- support logo, cover and additional image uploads in `AddItemModal`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481344ffd08326bb7047b393aaa924