### PR TITLE
Add image upload for hospitality hub categories

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -15,7 +15,8 @@ import {
   Input,
 } from "@chakra-ui/react";
 import { useForm } from "react-hook-form";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { useMediaUploader } from "@/hooks/useMediaUploader";
 
 interface AddCategoryModalProps {
   isOpen: boolean;
@@ -28,6 +29,7 @@ interface FormValues {
   description: string;
   customerId?: number;
   catOwnerUserId?: number;
+  imageUrl?: string;
 }
 
 export default function AddCategoryModal({
@@ -38,6 +40,14 @@ export default function AddCategoryModal({
   const { register, handleSubmit, reset, setValue } = useForm<FormValues>();
 
   const { user } = useUser();
+
+  const [imageUrl, setImageUrl] = useState<string>("");
+
+  const { uploadMediaFile, isUploading } = useMediaUploader(
+    "/api/hospitality-hub/uploadImage",
+    "imageUrl",
+    () => {},
+  );
 
   const customerId = user?.customerId;
   const userId = user?.userId;
@@ -52,6 +62,7 @@ export default function AddCategoryModal({
       method: "POST",
       body: JSON.stringify({
         ...data,
+        imageUrl,
         customerId,
         catOwnerUserId: userId,
       }),
@@ -78,6 +89,21 @@ export default function AddCategoryModal({
             <FormControl mb={4} isRequired>
               <FormLabel>Description</FormLabel>
               <Input {...register("description", { required: true })} />
+            </FormControl>
+            <FormControl mb={4}>
+              <FormLabel>Image</FormLabel>
+              <Input
+                type="file"
+                accept="image/*"
+                onChange={async (e) => {
+                  const file = e.target.files?.[0];
+                  if (!file) return;
+                  const data = await uploadMediaFile(file);
+                  setImageUrl(data.imageUrl);
+                  e.target.value = "";
+                }}
+                disabled={isUploading}
+              />
             </FormControl>
           </ModalBody>
           <ModalFooter>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -117,7 +117,7 @@ export function HospitalityHubMasonry({
           onClick={() => setSelected(category.id)}
         >
           <Image
-            src={category.image}
+            src={category.imageUrl || (category as any).image}
             alt={category.name}
             objectFit="cover"
             w="100%"

--- a/src/types/hospitalityHub.ts
+++ b/src/types/hospitalityHub.ts
@@ -23,4 +23,5 @@ export interface HospitalityCategory {
   description: string;
   customerId: string;
   catOwnerUserId: string;
+  imageUrl?: string;
 }


### PR DESCRIPTION
## Summary
- allow uploading an image when creating a Hospitality Hub category
- store uploaded image URL in the category
- display category.imageUrl in the masonry grid

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684816c26d188326a357afe8161d3824