### PR TITLE
Add reusable DragDropFileUpload and use in hospitality hub

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -17,7 +17,7 @@ import {
 } from "@chakra-ui/react";
 import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
-import { useMediaUploader } from "@/hooks/useMediaUploader";
+import DragDropFileUpload from "@/components/forms/DragDropFileUpload";
 
 interface AddItemModalProps {
   isOpen: boolean;
@@ -55,18 +55,6 @@ export default function AddItemModal({
   const [coverImageUrl, setCoverImageUrl] = useState<string>("");
   const [additionalImageUrlList, setAdditionalImageUrlList] = useState<string[]>([]);
 
-  const {
-    uploadMediaFile: uploadLogo,
-    isUploading: uploadingLogo,
-  } = useMediaUploader("/api/hospitality-hub/uploadImage", "imageUrl", () => {});
-  const {
-    uploadMediaFile: uploadCover,
-    isUploading: uploadingCover,
-  } = useMediaUploader("/api/hospitality-hub/uploadImage", "imageUrl", () => {});
-  const {
-    uploadMediaFile: uploadAdditional,
-    isUploading: uploadingAdditional,
-  } = useMediaUploader("/api/hospitality-hub/uploadImage", "imageUrl", () => {});
 
   const customerId = user?.customerId;
   const userId = user?.userId;
@@ -134,51 +122,32 @@ export default function AddItemModal({
             </FormControl>
             <FormControl mb={4}>
               <FormLabel>Logo Image</FormLabel>
-              <Input
-                type="file"
-                accept="image/*"
-                onChange={async (e) => {
-                  const file = e.target.files?.[0];
-                  if (!file) return;
-                  const data = await uploadLogo(file);
-                  setLogoImageUrl(data.imageUrl);
-                  e.target.value = "";
-                }}
-                disabled={uploadingLogo}
+              <DragDropFileUpload
+                uploadEndpoint="/api/hospitality-hub/uploadImage"
+                formKey="imageUrl"
+                placeholder="Drag & drop logo here"
+                onUploadComplete={(url) => setLogoImageUrl(url)}
               />
             </FormControl>
             <FormControl mb={4}>
               <FormLabel>Cover Image</FormLabel>
-              <Input
-                type="file"
-                accept="image/*"
-                onChange={async (e) => {
-                  const file = e.target.files?.[0];
-                  if (!file) return;
-                  const data = await uploadCover(file);
-                  setCoverImageUrl(data.imageUrl);
-                  e.target.value = "";
-                }}
-                disabled={uploadingCover}
+              <DragDropFileUpload
+                uploadEndpoint="/api/hospitality-hub/uploadImage"
+                formKey="imageUrl"
+                placeholder="Drag & drop cover image here"
+                onUploadComplete={(url) => setCoverImageUrl(url)}
               />
             </FormControl>
             <FormControl mb={4}>
               <FormLabel>Additional Images</FormLabel>
-              <Input
-                type="file"
-                accept="image/*"
+              <DragDropFileUpload
+                uploadEndpoint="/api/hospitality-hub/uploadImage"
+                formKey="imageUrl"
                 multiple
-                onChange={async (e) => {
-                  const files = Array.from(e.target.files || []);
-                  const urls: string[] = [];
-                  for (const file of files) {
-                    const data = await uploadAdditional(file as File);
-                    urls.push(data.imageUrl);
-                  }
-                  setAdditionalImageUrlList((prev) => [...prev, ...urls]);
-                  e.target.value = "";
-                }}
-                disabled={uploadingAdditional}
+                placeholder="Drag & drop additional images"
+                onUploadComplete={(url) =>
+                  setAdditionalImageUrlList((prev) => [...prev, url])
+                }
               />
             </FormControl>
           </ModalBody>

--- a/src/components/forms/DragDropFileUpload.tsx
+++ b/src/components/forms/DragDropFileUpload.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import React, { useState, useRef, useCallback } from "react";
+import {
+  Box,
+  Flex,
+  VStack,
+  Spinner,
+  Image,
+  Text,
+  Button,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import { useMediaUploader } from "@/hooks/useMediaUploader";
+
+interface DragDropFileUploadProps {
+  uploadEndpoint: string;
+  formKey: string;
+  onUploadComplete?: (url: string) => void;
+  placeholder?: string;
+  initialUrl?: string;
+  multiple?: boolean;
+}
+
+export default function DragDropFileUpload({
+  uploadEndpoint,
+  formKey,
+  onUploadComplete,
+  placeholder = "Drag & drop file here",
+  initialUrl = "",
+  multiple = false,
+}: DragDropFileUploadProps) {
+  const { isUploading, uploadMediaFile } = useMediaUploader(
+    uploadEndpoint,
+    formKey,
+    () => {}
+  );
+
+  const [previewUrl, setPreviewUrl] = useState(initialUrl);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const borderColor = useColorModeValue("gray.400", "gray.600");
+  const hoverBorderColor = useColorModeValue("gray.200", "gray.400");
+
+  const extractUrl = (data: any): string =>
+    data.imageUrl || data.url || data.resource?.imageUrl || "";
+
+  const handleUploadSuccess = (url: string) => {
+    if (!multiple) setPreviewUrl(url);
+    onUploadComplete?.(url);
+  };
+
+  const handleFiles = async (files: FileList | File[]) => {
+    const fileArray = multiple ? Array.from(files) : [files[0]];
+    for (const file of fileArray) {
+      if (!file) continue;
+      if (!multiple) {
+        const localUrl = URL.createObjectURL(file);
+        setPreviewUrl(localUrl);
+      }
+      try {
+        const data = await uploadMediaFile(file);
+        const newUrl = extractUrl(data);
+        handleUploadSuccess(newUrl);
+      } catch {
+        // error toast already shown by hook
+      }
+    }
+  };
+
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const onDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault();
+      const files = e.dataTransfer.files;
+      if (!files || files.length === 0) return;
+      await handleFiles(files);
+    },
+    [handleFiles]
+  );
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    await handleFiles(files);
+    e.target.value = "";
+  };
+
+  return (
+    <VStack w="100%" align="center" spacing={4}>
+      <Box
+        w="100%"
+        maxW="400px"
+        p={6}
+        border="2px dashed"
+        background="rgba(255, 255, 255, 0.1)"
+        borderColor={borderColor}
+        borderRadius="md"
+        textAlign="center"
+        position="relative"
+        cursor="pointer"
+        _hover={{ borderColor: hoverBorderColor }}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+      >
+        {isUploading && (
+          <Flex
+            position="absolute"
+            inset={0}
+            bg="rgba(255,255,255,0.8)"
+            align="center"
+            justify="center"
+            borderRadius="md"
+            zIndex={2}
+          >
+            <Spinner size="lg" />
+          </Flex>
+        )}
+
+        <Box mb={4}>
+          {previewUrl ? (
+            <Image src={previewUrl} alt="preview" maxH="100px" mx="auto" />
+          ) : (
+            <Text color="white" fontSize={18}>
+              {placeholder}
+            </Text>
+          )}
+        </Box>
+
+        <Button
+          size="sm"
+          colorScheme="blue"
+          mt={previewUrl ? 0 : 4}
+          onClick={(e) => {
+            e.stopPropagation();
+            inputRef.current?.click();
+          }}
+          disabled={isUploading}
+        >
+          {previewUrl ? "Change File" : "Browse files"}
+        </Button>
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple={multiple}
+          style={{ display: "none" }}
+          onChange={onFileChange}
+          disabled={isUploading}
+        />
+      </Box>
+    </VStack>
+  );
+}


### PR DESCRIPTION
## Summary
- add DragDropFileUpload component extracted from LogoUpload
- use DragDropFileUpload in the Hospitality Hub add item form

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684819770ed0832692f9449b81ad9b47