### PR TITLE
Fix image uploads in hospitality hub

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -127,6 +127,7 @@ export default function AddItemModal({
                 formKey="imageUrl"
                 placeholder="Drag & drop logo here"
                 onUploadComplete={(url) => setLogoImageUrl(url)}
+                onRemove={() => setLogoImageUrl("")}
               />
             </FormControl>
             <FormControl mb={4}>
@@ -136,6 +137,7 @@ export default function AddItemModal({
                 formKey="imageUrl"
                 placeholder="Drag & drop cover image here"
                 onUploadComplete={(url) => setCoverImageUrl(url)}
+                onRemove={() => setCoverImageUrl("")}
               />
             </FormControl>
             <FormControl mb={4}>
@@ -147,6 +149,9 @@ export default function AddItemModal({
                 placeholder="Drag & drop additional images"
                 onUploadComplete={(url) =>
                   setAdditionalImageUrlList((prev) => [...prev, url])
+                }
+                onRemove={(url) =>
+                  setAdditionalImageUrlList((prev) => prev.filter((u) => u !== url))
                 }
               />
             </FormControl>


### PR DESCRIPTION
## Summary
- support removing uploaded images in drag/drop component
- show uploaded additional images and enable removal
- wire up removal handlers in add item modal

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68481e78ec5c8326bc3f5392e177856a