### PR TITLE
Fix hospitality hub error handling

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -16,6 +16,7 @@ import {
 } from "@chakra-ui/react";
 import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
+import { useToast } from "@chakra-ui/react";
 import { useMediaUploader } from "@/hooks/useMediaUploader";
 
 interface AddCategoryModalProps {
@@ -38,6 +39,7 @@ export default function AddCategoryModal({
   onCreated,
 }: AddCategoryModalProps) {
   const { register, handleSubmit, reset, setValue } = useForm<FormValues>();
+  const toast = useToast();
 
   const { user } = useUser();
 
@@ -58,7 +60,7 @@ export default function AddCategoryModal({
   }, [customerId, userId, setValue]);
 
   const onSubmit = async (data: FormValues) => {
-    await fetch("/api/hospitality-hub/categories", {
+    const res = await fetch("/api/hospitality-hub/categories", {
       method: "POST",
       body: JSON.stringify({
         ...data,
@@ -67,6 +69,21 @@ export default function AddCategoryModal({
         catOwnerUserId: userId,
       }),
     });
+
+    const result = await res.json();
+
+    if (!res.ok) {
+      toast({
+        title: result.error || "Failed to create category.",
+        description: result.details,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+      return;
+    }
+
     onCreated();
     reset();
     onClose();

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -17,6 +17,7 @@ import {
 } from "@chakra-ui/react";
 import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
+import { useToast } from "@chakra-ui/react";
 import DragDropFileUpload from "@/components/forms/DragDropFileUpload";
 
 interface AddItemModalProps {
@@ -48,6 +49,7 @@ export default function AddItemModal({
   onCreated,
 }: AddItemModalProps) {
   const { register, handleSubmit, reset, setValue } = useForm<FormValues>();
+  const toast = useToast();
 
   const { user } = useUser();
 
@@ -65,7 +67,7 @@ export default function AddItemModal({
   }, [customerId, userId, setValue]);
 
   const onSubmit = async (data: FormValues) => {
-    await fetch("/api/hospitality-hub/items", {
+    const res = await fetch("/api/hospitality-hub/items", {
       method: "POST",
       body: JSON.stringify({
         ...data,
@@ -77,6 +79,21 @@ export default function AddItemModal({
         hospitalityCatId: categoryId,
       }),
     });
+
+    const result = await res.json();
+
+    if (!res.ok) {
+      toast({
+        title: result.error || "Failed to create item.",
+        description: result.details,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+      return;
+    }
+
     onCreated();
     reset();
     onClose();

--- a/src/app/api/hospitality-hub/categories/route.ts
+++ b/src/app/api/hospitality-hub/categories/route.ts
@@ -56,7 +56,10 @@ export async function POST(req: NextRequest) {
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data?.error || "Failed to create category." },
+        {
+          error: data?.error || "Failed to create category.",
+          details: data?.details,
+        },
         { status: response.status },
       );
     }
@@ -87,7 +90,10 @@ export async function PUT(req: NextRequest) {
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data?.error || "Failed to update category." },
+        {
+          error: data?.error || "Failed to update category.",
+          details: data?.details,
+        },
         { status: response.status },
       );
     }
@@ -126,7 +132,10 @@ export async function DELETE(req: NextRequest) {
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data?.error || "Failed to delete category." },
+        {
+          error: data?.error || "Failed to delete category.",
+          details: data?.details,
+        },
         { status: response.status },
       );
     }

--- a/src/app/api/hospitality-hub/items/route.ts
+++ b/src/app/api/hospitality-hub/items/route.ts
@@ -56,7 +56,10 @@ export async function POST(req: NextRequest) {
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data?.error || "Failed to create item." },
+        {
+          error: data?.error || "Failed to create item.",
+          details: data?.details,
+        },
         { status: response.status },
       );
     }
@@ -87,7 +90,10 @@ export async function PUT(req: NextRequest) {
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data?.error || "Failed to update item." },
+        {
+          error: data?.error || "Failed to update item.",
+          details: data?.details,
+        },
         { status: response.status },
       );
     }
@@ -126,7 +132,10 @@ export async function DELETE(req: NextRequest) {
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: data?.error || "Failed to delete item." },
+        {
+          error: data?.error || "Failed to delete item.",
+          details: data?.details,
+        },
         { status: response.status },
       );
     }


### PR DESCRIPTION
## Summary
- include backend `details` in hospitality hub API responses
- show toast errors in hospitality hub admin modals when creation fails

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684826f1ef08832682a923fe5b9a279c