### PR TITLE
Fix hospitality item fetching

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -40,7 +40,7 @@ export function HospitalityHubMasonry({
     setModalOpen(true);
     setModalLoading(true);
     try {
-      const res = await fetch(`/api/hospitality-hub/${selected}/${itemId}`);
+      const res = await fetch(`/api/hospitality-hub/items?id=${itemId}`);
       const data = await res.json();
       if (res.ok) {
         setSelectedItem(data.resource);

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { HospitalityItem } from '@/types/hospitalityHub';
+import { useState, useEffect } from "react";
+import { HospitalityItem } from "@/types/hospitalityHub";
 
 export function useHospitalityItems(categoryKey?: string | null) {
   const [items, setItems] = useState<HospitalityItem[]>([]);
@@ -11,13 +11,13 @@ export function useHospitalityItems(categoryKey?: string | null) {
     setLoading(true);
     try {
       const res = await fetch(
-        `/api/hospitality-hub/items?hospitalityCatId=${categoryKey}`,
+        `/api/hospitality-hub/category-items?hospitalityCatId=${categoryKey}`,
       );
       const data = await res.json();
       if (res.ok) {
         setItems(data.resource || []);
       } else {
-        throw new Error(data?.error || 'Failed to fetch items');
+        throw new Error(data?.error || "Failed to fetch items");
       }
     } catch (err: any) {
       console.error(err);

--- a/src/app/api/hospitality-hub/category-items/route.ts
+++ b/src/app/api/hospitality-hub/category-items/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function GET(req: NextRequest) {
+  const cookieStore = cookies();
+  const authToken = cookieStore.get("auth_token")?.value;
+
+  const hospitalityCatId = req.nextUrl.searchParams.get("hospitalityCatId");
+  if (!hospitalityCatId) {
+    return NextResponse.json(
+      { error: "Missing hospitalityCatId" },
+      { status: 400 },
+    );
+  }
+
+  const url = `${process.env.BE_URL}/userHospitalityItem/allBy?hospitalityCatId=${hospitalityCatId}`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: authToken ? `Bearer ${authToken}` : "",
+      },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: data?.error || "Failed to fetch items." },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({ resource: data.resource });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message || "An error occurred." },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add category items API route to proxy `/userHospitalityItem/allBy`
- use the new endpoint when fetching items for a selected category

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849719304cc8326a0addb2d3b50c396