### PR TITLE
Add category management actions

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteCategoryModal.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  Text,
+  Spinner,
+} from "@chakra-ui/react";
+import { HospitalityCategory } from "@/types/hospitalityHub";
+import useHospitalityItems from "../../hooks/useHospitalityItems";
+import { useToast } from "@chakra-ui/react";
+
+interface DeleteCategoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  category: HospitalityCategory | null;
+  onDeleted: () => void;
+}
+
+export default function DeleteCategoryModal({
+  isOpen,
+  onClose,
+  category,
+  onDeleted,
+}: DeleteCategoryModalProps) {
+  const toast = useToast();
+  const { items, loading } = useHospitalityItems(
+    isOpen && category ? category.id : undefined,
+  );
+
+  if (!category) return null;
+
+  const handleDelete = async () => {
+    const res = await fetch(
+      `/api/hospitality-hub/categories?id=${category.id}`,
+      {
+        method: "DELETE",
+      },
+    );
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      toast({
+        title: data.error || "Failed to delete category.",
+        description: data.details,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+      return;
+    }
+
+    onDeleted();
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Delete Category</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text>
+            Are you sure you want to delete {category.name}?
+          </Text>
+          {loading ? (
+            <Spinner size="sm" mt={2} />
+          ) : items.length > 0 ? (
+            <Text mt={2}>
+              This category contains {items.length} item
+              {items.length === 1 ? "" : "s"} which will also be deleted.
+            </Text>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="red" onClick={handleDelete}>
+            Delete
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,14 +1,24 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Button, VStack, Spinner, Select } from "@chakra-ui/react";
+import {
+  VStack,
+  Spinner,
+  Select,
+  IconButton,
+  HStack,
+} from "@chakra-ui/react";
+import { FiPlus, FiEdit2, FiTrash2 } from "react-icons/fi";
 import { HospitalityCategory } from "@/types/hospitalityHub";
 import useHospitalityCategories from "../../hooks/useHospitalityCategories";
 import CategoryTabContent from "./CategoryTabContent";
 import AddCategoryModal from "./AddCategoryModal";
+import DeleteCategoryModal from "./DeleteCategoryModal";
 
 export const HospitalityHubAdminClientInner = () => {
-  const [modalOpen, setModalOpen] = useState(false);
+  const [categoryModalOpen, setCategoryModalOpen] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<HospitalityCategory | null>(null);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const { categories, loading, refresh } = useHospitalityCategories();
   const [selectedCategory, setSelectedCategory] = useState<HospitalityCategory | null>(null);
 
@@ -20,37 +30,72 @@ export const HospitalityHubAdminClientInner = () => {
 
   return (
     <VStack w="100%" spacing={4} align="stretch">
-      <Button alignSelf="flex-end" onClick={() => setModalOpen(true)}>
-        Add Category
-      </Button>
       {loading ? (
         <Spinner />
       ) : (
         <>
-          <Select
-            value={selectedCategory?.id?.toString() || ""}
-            onChange={(e) => {
-              const value = e.target.value;
-              const cat = categories.find((c) => String(c.id) === value);
-              setSelectedCategory(cat || null);
-            }}
-            color="primaryTextColor"
-            bg="elementBG"
-            sx={{ option: { backgroundColor: "var(--chakra-colors-elementBG)" } }}
-          >
-            {categories.map((category) => (
-              <option key={category.id} value={String(category.id)}>
-                {category.name}
-              </option>
-            ))}
-          </Select>
+          <HStack>
+            <Select
+              value={selectedCategory?.id?.toString() || ""}
+              onChange={(e) => {
+                const value = e.target.value;
+                const cat = categories.find((c) => String(c.id) === value);
+                setSelectedCategory(cat || null);
+              }}
+              color="primaryTextColor"
+              bg="elementBG"
+              sx={{ option: { backgroundColor: "var(--chakra-colors-elementBG)" } }}
+            >
+              {categories.map((category) => (
+                <option key={category.id} value={String(category.id)}>
+                  {category.name}
+                </option>
+              ))}
+            </Select>
+            <IconButton
+              aria-label="Add Category"
+              icon={<FiPlus />}
+              onClick={() => {
+                setEditingCategory(null);
+                setCategoryModalOpen(true);
+              }}
+              size="sm"
+            />
+            <IconButton
+              aria-label="Edit Category"
+              icon={<FiEdit2 />}
+              onClick={() => {
+                if (selectedCategory) {
+                  setEditingCategory(selectedCategory);
+                  setCategoryModalOpen(true);
+                }
+              }}
+              size="sm"
+              isDisabled={!selectedCategory}
+            />
+            <IconButton
+              aria-label="Delete Category"
+              icon={<FiTrash2 />}
+              onClick={() => setDeleteModalOpen(true)}
+              size="sm"
+              colorScheme="red"
+              isDisabled={!selectedCategory}
+            />
+          </HStack>
           {selectedCategory && <CategoryTabContent category={selectedCategory} />}
         </>
       )}
       <AddCategoryModal
-        isOpen={modalOpen}
-        onClose={() => setModalOpen(false)}
+        isOpen={categoryModalOpen}
+        onClose={() => setCategoryModalOpen(false)}
         onCreated={refresh}
+        category={editingCategory}
+      />
+      <DeleteCategoryModal
+        isOpen={deleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+        category={selectedCategory}
+        onDeleted={refresh}
       />
     </VStack>
   );


### PR DESCRIPTION
## Summary
- update `AddCategoryModal` to support editing
- add new `DeleteCategoryModal` for confirming deletion
- show create, edit and delete buttons next to category dropdown

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react' etc.)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684979778e0c8326a89d356a529c5d27