### PR TITLE
Fix category modal prop handling

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -39,6 +39,7 @@ export default function AddCategoryModal({
   isOpen,
   onClose,
   onCreated,
+  category,
 }: AddCategoryModalProps) {
   const { register, handleSubmit, reset, setValue } = useForm<FormValues>();
   const toast = useToast();


### PR DESCRIPTION
## Summary
- include missing `category` prop in `AddCategoryModal`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68497b04f138832686de9c25bd344f0b