### PR TITLE
Fix hospitality hub category deletion endpoint

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteCategoryModal.tsx
@@ -38,7 +38,7 @@ export default function DeleteCategoryModal({
 
   const handleDelete = async () => {
     const res = await fetch(
-      `/api/hospitality-hub/categories?id=${category.id}`,
+      `/api/hospitality-hub/categories/${category.id}`,
       {
         method: "DELETE",
       },

--- a/src/app/api/hospitality-hub/categories/[id]/route.ts
+++ b/src/app/api/hospitality-hub/categories/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const cookieStore = cookies();
+  const authToken = cookieStore.get("auth_token")?.value;
+  const id = params.id;
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing id" }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(
+      `${process.env.BE_URL}/userHospitalityCategory/${id}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: authToken ? `Bearer ${authToken}` : "",
+        },
+      },
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        {
+          error: data?.error || "Failed to delete category.",
+          details: data?.details,
+        },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({ resource: data.resource });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message || "An error occurred." },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create dynamic API route for deleting hospitality categories via `/api/hospitality-hub/categories/[id]`
- update `DeleteCategoryModal` to call the new endpoint using the required path format

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497e011a8883269c863dfa71860c68