### PR TITLE
Add edit/delete controls to hospitality hub admin items

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -2,10 +2,11 @@
 
 import { Spinner, VStack, Button } from "@chakra-ui/react";
 import HospitalityItemsMasonry from "./HospitalityItemsMasonry";
-import { HospitalityCategory } from "@/types/hospitalityHub";
+import { HospitalityCategory, HospitalityItem } from "@/types/hospitalityHub";
 import useHospitalityItems from "../../hooks/useHospitalityItems";
 import { useState } from "react";
 import AddItemModal from "./AddItemModal";
+import DeleteItemModal from "./DeleteItemModal";
 
 interface CategoryTabContentProps {
   category: HospitalityCategory;
@@ -14,6 +15,9 @@ interface CategoryTabContentProps {
 export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
   const { items, loading, refresh } = useHospitalityItems(category.id);
   const [modalOpen, setModalOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<HospitalityItem | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deletingItem, setDeletingItem] = useState<HospitalityItem | null>(null);
 
   if (loading) {
     return <Spinner />;
@@ -21,7 +25,13 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
 
   return (
     <VStack w="100%" align="stretch" spacing={4}>
-      <Button alignSelf="flex-end" onClick={() => setModalOpen(true)}>
+      <Button
+        alignSelf="flex-end"
+        onClick={() => {
+          setEditingItem(null);
+          setModalOpen(true);
+        }}
+      >
         Add Item
       </Button>
       {loading ? (
@@ -30,6 +40,14 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
         <HospitalityItemsMasonry
           items={items}
           optionalFields={category.optionalFields || []}
+          onEdit={(item) => {
+            setEditingItem(item);
+            setModalOpen(true);
+          }}
+          onDelete={(item) => {
+            setDeletingItem(item);
+            setDeleteOpen(true);
+          }}
         />
       )}
       <AddItemModal
@@ -37,6 +55,13 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
         onClose={() => setModalOpen(false)}
         onCreated={refresh}
         categoryId={category.id}
+        item={editingItem}
+      />
+      <DeleteItemModal
+        isOpen={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        item={deletingItem}
+        onDeleted={refresh}
       />
     </VStack>
   );

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteItemModal.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  Text,
+} from "@chakra-ui/react";
+import { useToast } from "@chakra-ui/react";
+import { HospitalityItem } from "@/types/hospitalityHub";
+
+interface DeleteItemModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  item: HospitalityItem | null;
+  onDeleted: () => void;
+}
+
+export default function DeleteItemModal({
+  isOpen,
+  onClose,
+  item,
+  onDeleted,
+}: DeleteItemModalProps) {
+  const toast = useToast();
+  if (!item) return null;
+
+  const handleDelete = async () => {
+    const res = await fetch(`/api/hospitality-hub/items?id=${item.id}`, {
+      method: "DELETE",
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      toast({
+        title: data.error || "Failed to delete item.",
+        description: data.details,
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+      return;
+    }
+
+    onDeleted();
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Delete Item</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text>Are you sure you want to delete {item.name}?</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button colorScheme="red" onClick={handleDelete}>
+            Delete
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
@@ -1,26 +1,53 @@
 "use client";
 
-import { SimpleGrid } from "@chakra-ui/react";
+import { Box, HStack, IconButton, SimpleGrid } from "@chakra-ui/react";
 import HospitalityItemCard from "../../components/HospitalityItemCard";
 import { HospitalityItem } from "@/types/hospitalityHub";
+import { FiEdit2, FiTrash2 } from "react-icons/fi";
 
 interface HospitalityItemsMasonryProps {
   items: HospitalityItem[];
   optionalFields?: string[];
+  onEdit?: (item: HospitalityItem) => void;
+  onDelete?: (item: HospitalityItem) => void;
 }
 
 export default function HospitalityItemsMasonry({
   items,
   optionalFields = [],
+  onEdit,
+  onDelete,
 }: HospitalityItemsMasonryProps) {
   return (
     <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
       {items.map((item: HospitalityItem) => (
-        <HospitalityItemCard
-          key={item.id}
-          item={item}
-          optionalFields={optionalFields}
-        />
+        <Box key={item.id} position="relative">
+          <HospitalityItemCard
+            item={item}
+            optionalFields={optionalFields}
+          />
+          {(onEdit || onDelete) && (
+            <HStack position="absolute" top={2} right={2} spacing={1}>
+              {onEdit && (
+                <IconButton
+                  aria-label="Edit Item"
+                  size="sm"
+                  icon={<FiEdit2 />}
+                  onClick={() => onEdit(item)}
+                />
+              )}
+              {onDelete && (
+                <IconButton
+                  aria-label="Delete Item"
+                  size="sm"
+                  colorScheme="red"
+                  icon={<FiTrash2 />}
+                  onClick={() => onDelete(item)}
+                />
+              )}
+            </HStack>
+          )}
+        </Box>
       ))}
     </SimpleGrid>
   );


### PR DESCRIPTION
## Summary
- extend AddItemModal to support editing existing items
- add DeleteItemModal for item deletion
- show Edit/Delete buttons on each item card
- wire up item editing and deletion in CategoryTabContent

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684983a9a4288326bded99f84d6aced1