### PR TITLE
Add disable buttons in hospitality hub admin

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Spinner, VStack, Button } from "@chakra-ui/react";
+import { Spinner, VStack, Button, useToast } from "@chakra-ui/react";
 import HospitalityItemsMasonry from "./HospitalityItemsMasonry";
 import { HospitalityCategory, HospitalityItem } from "@/types/hospitalityHub";
 import useHospitalityItems from "../../hooks/useHospitalityItems";
@@ -17,7 +17,10 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<HospitalityItem | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [deletingItem, setDeletingItem] = useState<HospitalityItem | null>(null);
+  const [deletingItem, setDeletingItem] = useState<HospitalityItem | null>(
+    null,
+  );
+  const toast = useToast();
 
   if (loading) {
     return <Spinner />;
@@ -47,6 +50,24 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
           onDelete={(item) => {
             setDeletingItem(item);
             setDeleteOpen(true);
+          }}
+          onToggleActive={async (item) => {
+            const res = await fetch("/api/hospitality-hub/items", {
+              method: "PUT",
+              body: JSON.stringify({ id: item.id, isActive: !item.isActive }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+              toast({
+                title: data.error || "Failed to update item.",
+                status: "error",
+                duration: 5000,
+                isClosable: true,
+                position: "bottom-right",
+              });
+              return;
+            }
+            refresh();
           }}
         />
       )}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { VStack, Spinner, Select, IconButton, HStack } from "@chakra-ui/react";
 import {
-  VStack,
-  Spinner,
-  Select,
-  IconButton,
-  HStack,
-} from "@chakra-ui/react";
-import { FiPlus, FiEdit2, FiTrash2 } from "react-icons/fi";
+  FiPlus,
+  FiEdit2,
+  FiTrash2,
+  FiToggleLeft,
+  FiToggleRight,
+} from "react-icons/fi";
 import { HospitalityCategory } from "@/types/hospitalityHub";
 import useHospitalityCategories from "../../hooks/useHospitalityCategories";
 import CategoryTabContent from "./CategoryTabContent";
@@ -17,10 +17,12 @@ import DeleteCategoryModal from "./DeleteCategoryModal";
 
 export const HospitalityHubAdminClientInner = () => {
   const [categoryModalOpen, setCategoryModalOpen] = useState(false);
-  const [editingCategory, setEditingCategory] = useState<HospitalityCategory | null>(null);
+  const [editingCategory, setEditingCategory] =
+    useState<HospitalityCategory | null>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const { categories, loading, refresh } = useHospitalityCategories();
-  const [selectedCategory, setSelectedCategory] = useState<HospitalityCategory | null>(null);
+  const [selectedCategory, setSelectedCategory] =
+    useState<HospitalityCategory | null>(null);
 
   useEffect(() => {
     if (!selectedCategory && categories.length > 0) {
@@ -44,7 +46,9 @@ export const HospitalityHubAdminClientInner = () => {
               }}
               color="primaryTextColor"
               bg="elementBG"
-              sx={{ option: { backgroundColor: "var(--chakra-colors-elementBG)" } }}
+              sx={{
+                option: { backgroundColor: "var(--chakra-colors-elementBG)" },
+              }}
             >
               {categories.map((category) => (
                 <option key={category.id} value={String(category.id)}>
@@ -81,8 +85,43 @@ export const HospitalityHubAdminClientInner = () => {
               colorScheme="red"
               isDisabled={!selectedCategory}
             />
+            <IconButton
+              aria-label={
+                selectedCategory?.isActive
+                  ? "Disable Category"
+                  : "Enable Category"
+              }
+              icon={
+                selectedCategory?.isActive ? (
+                  <FiToggleLeft />
+                ) : (
+                  <FiToggleRight />
+                )
+              }
+              onClick={async () => {
+                if (!selectedCategory) return;
+                const res = await fetch("/api/hospitality-hub/categories", {
+                  method: "PUT",
+                  body: JSON.stringify({
+                    id: selectedCategory.id,
+                    isActive: !selectedCategory.isActive,
+                  }),
+                });
+                if (res.ok) {
+                  refresh();
+                  setSelectedCategory({
+                    ...selectedCategory,
+                    isActive: !selectedCategory.isActive,
+                  });
+                }
+              }}
+              size="sm"
+              isDisabled={!selectedCategory}
+            />
           </HStack>
-          {selectedCategory && <CategoryTabContent category={selectedCategory} />}
+          {selectedCategory && (
+            <CategoryTabContent category={selectedCategory} />
+          )}
         </>
       )}
       <AddCategoryModal

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
@@ -3,13 +3,14 @@
 import { Box, HStack, IconButton, SimpleGrid } from "@chakra-ui/react";
 import HospitalityItemCard from "../../components/HospitalityItemCard";
 import { HospitalityItem } from "@/types/hospitalityHub";
-import { FiEdit2, FiTrash2 } from "react-icons/fi";
+import { FiEdit2, FiTrash2, FiToggleLeft, FiToggleRight } from "react-icons/fi";
 
 interface HospitalityItemsMasonryProps {
   items: HospitalityItem[];
   optionalFields?: string[];
   onEdit?: (item: HospitalityItem) => void;
   onDelete?: (item: HospitalityItem) => void;
+  onToggleActive?: (item: HospitalityItem) => void;
 }
 
 export default function HospitalityItemsMasonry({
@@ -17,16 +18,14 @@ export default function HospitalityItemsMasonry({
   optionalFields = [],
   onEdit,
   onDelete,
+  onToggleActive,
 }: HospitalityItemsMasonryProps) {
   return (
     <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
       {items.map((item: HospitalityItem) => (
         <Box key={item.id} position="relative">
-          <HospitalityItemCard
-            item={item}
-            optionalFields={optionalFields}
-          />
-          {(onEdit || onDelete) && (
+          <HospitalityItemCard item={item} optionalFields={optionalFields} />
+          {(onEdit || onDelete || onToggleActive) && (
             <HStack position="absolute" top={2} right={2} spacing={1}>
               {onEdit && (
                 <IconButton
@@ -43,6 +42,14 @@ export default function HospitalityItemsMasonry({
                   colorScheme="red"
                   icon={<FiTrash2 />}
                   onClick={() => onDelete(item)}
+                />
+              )}
+              {onToggleActive && (
+                <IconButton
+                  aria-label={item.isActive ? "Disable Item" : "Enable Item"}
+                  size="sm"
+                  icon={item.isActive ? <FiToggleLeft /> : <FiToggleRight />}
+                  onClick={() => onToggleActive(item)}
                 />
               )}
             </HStack>

--- a/src/types/hospitalityHub.ts
+++ b/src/types/hospitalityHub.ts
@@ -23,5 +23,6 @@ export interface HospitalityCategory {
   description: string;
   customerId: string;
   catOwnerUserId: string;
+  isActive: boolean;
   imageUrl?: string;
 }


### PR DESCRIPTION
## Summary
- support `isActive` flag on hospitality hub categories
- add toggle buttons to enable/disable categories
- allow item cards in masonry to be toggled active or inactive
- wire toggle logic through PUT API calls

## Testing
- `npm run lint` *(fails: next not found)*
- `npx prettier -w src/types/hospitalityHub.ts src/app/'(site)'/'(apps-non-standard)'/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx src/app/'(site)'/'(apps-non-standard)'/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx src/app/'(site)'/'(apps-non-standard)'/hospitality-hub/admin/components/CategoryTabContent.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68498b4ef604832681ec2cf4fc8e82a3