### PR TITLE
Add tooltips and switch toggle in Hospitality Hub admin

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { VStack, Spinner, Select, IconButton, HStack } from "@chakra-ui/react";
+import {
+  VStack,
+  Spinner,
+  Select,
+  IconButton,
+  HStack,
+  Tooltip,
+  Switch,
+} from "@chakra-ui/react";
 import {
   FiPlus,
   FiEdit2,
@@ -56,68 +64,78 @@ export const HospitalityHubAdminClientInner = () => {
                 </option>
               ))}
             </Select>
-            <IconButton
-              aria-label="Add Category"
-              icon={<FiPlus />}
-              onClick={() => {
-                setEditingCategory(null);
-                setCategoryModalOpen(true);
-              }}
-              size="sm"
-            />
-            <IconButton
-              aria-label="Edit Category"
-              icon={<FiEdit2 />}
-              onClick={() => {
-                if (selectedCategory) {
-                  setEditingCategory(selectedCategory);
+            <Tooltip label="Add Category">
+              <IconButton
+                aria-label="Add Category"
+                icon={<FiPlus />}
+                onClick={() => {
+                  setEditingCategory(null);
                   setCategoryModalOpen(true);
-                }
-              }}
-              size="sm"
-              isDisabled={!selectedCategory}
-            />
-            <IconButton
-              aria-label="Delete Category"
-              icon={<FiTrash2 />}
-              onClick={() => setDeleteModalOpen(true)}
-              size="sm"
-              colorScheme="red"
-              isDisabled={!selectedCategory}
-            />
-            <IconButton
-              aria-label={
+                }}
+                size="sm"
+                colorScheme="green"
+              />
+            </Tooltip>
+            <Tooltip label="Edit Category">
+              <IconButton
+                aria-label="Edit Category"
+                icon={<FiEdit2 />}
+                onClick={() => {
+                  if (selectedCategory) {
+                    setEditingCategory(selectedCategory);
+                    setCategoryModalOpen(true);
+                  }
+                }}
+                size="sm"
+                isDisabled={!selectedCategory}
+                colorScheme="blue"
+              />
+            </Tooltip>
+            <Tooltip label="Delete Category">
+              <IconButton
+                aria-label="Delete Category"
+                icon={<FiTrash2 />}
+                onClick={() => setDeleteModalOpen(true)}
+                size="sm"
+                colorScheme="red"
+                isDisabled={!selectedCategory}
+              />
+            </Tooltip>
+            <Tooltip
+              label={
                 selectedCategory?.isActive
                   ? "Disable Category"
                   : "Enable Category"
               }
-              icon={
-                selectedCategory?.isActive ? (
-                  <FiToggleLeft />
-                ) : (
-                  <FiToggleRight />
-                )
-              }
-              onClick={async () => {
-                if (!selectedCategory) return;
-                const res = await fetch("/api/hospitality-hub/categories", {
-                  method: "PUT",
-                  body: JSON.stringify({
-                    id: selectedCategory.id,
-                    isActive: !selectedCategory.isActive,
-                  }),
-                });
-                if (res.ok) {
-                  refresh();
-                  setSelectedCategory({
-                    ...selectedCategory,
-                    isActive: !selectedCategory.isActive,
-                  });
+            >
+              <Switch
+                aria-label={
+                  selectedCategory?.isActive
+                    ? "Disable Category"
+                    : "Enable Category"
                 }
-              }}
-              size="sm"
-              isDisabled={!selectedCategory}
-            />
+                isChecked={selectedCategory?.isActive}
+                onChange={async () => {
+                  if (!selectedCategory) return;
+                  const res = await fetch("/api/hospitality-hub/categories", {
+                    method: "PUT",
+                    body: JSON.stringify({
+                      id: selectedCategory.id,
+                      isActive: !selectedCategory.isActive,
+                    }),
+                  });
+                  if (res.ok) {
+                    refresh();
+                    setSelectedCategory({
+                      ...selectedCategory,
+                      isActive: !selectedCategory.isActive,
+                    });
+                  }
+                }}
+                size="sm"
+                isDisabled={!selectedCategory}
+              />
+            </Tooltip>
           </HStack>
           {selectedCategory && (
             <CategoryTabContent category={selectedCategory} />

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, HStack, IconButton, SimpleGrid } from "@chakra-ui/react";
+import { Box, HStack, IconButton, SimpleGrid, Tooltip, Switch } from "@chakra-ui/react";
 import HospitalityItemCard from "../../components/HospitalityItemCard";
 import { HospitalityItem } from "@/types/hospitalityHub";
 import { FiEdit2, FiTrash2, FiToggleLeft, FiToggleRight } from "react-icons/fi";
@@ -28,29 +28,36 @@ export default function HospitalityItemsMasonry({
           {(onEdit || onDelete || onToggleActive) && (
             <HStack position="absolute" top={2} right={2} spacing={1}>
               {onEdit && (
-                <IconButton
-                  aria-label="Edit Item"
-                  size="sm"
-                  icon={<FiEdit2 />}
-                  onClick={() => onEdit(item)}
-                />
+                <Tooltip label="Edit Item">
+                  <IconButton
+                    aria-label="Edit Item"
+                    size="sm"
+                    icon={<FiEdit2 />}
+                    onClick={() => onEdit(item)}
+                    colorScheme="blue"
+                  />
+                </Tooltip>
               )}
               {onDelete && (
-                <IconButton
-                  aria-label="Delete Item"
-                  size="sm"
-                  colorScheme="red"
-                  icon={<FiTrash2 />}
-                  onClick={() => onDelete(item)}
-                />
+                <Tooltip label="Delete Item">
+                  <IconButton
+                    aria-label="Delete Item"
+                    size="sm"
+                    colorScheme="red"
+                    icon={<FiTrash2 />}
+                    onClick={() => onDelete(item)}
+                  />
+                </Tooltip>
               )}
               {onToggleActive && (
-                <IconButton
-                  aria-label={item.isActive ? "Disable Item" : "Enable Item"}
-                  size="sm"
-                  icon={item.isActive ? <FiToggleLeft /> : <FiToggleRight />}
-                  onClick={() => onToggleActive(item)}
-                />
+                <Tooltip label={item.isActive ? "Disable Item" : "Enable Item"}>
+                  <Switch
+                    aria-label={item.isActive ? "Disable Item" : "Enable Item"}
+                    size="sm"
+                    isChecked={item.isActive}
+                    onChange={() => onToggleActive(item)}
+                  />
+                </Tooltip>
               )}
             </HStack>
           )}


### PR DESCRIPTION
## Summary
- add tooltip & color scheme to category action buttons
- replace category toggle button with a Chakra `Switch`
- add tooltip & color scheme to item action buttons
- replace item toggle button with a Chakra `Switch`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498df73cac8326886bcc7c4cb540fb