### PR TITLE
Fix tooltip bug on hospitality hub switch

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -107,6 +107,7 @@ export const HospitalityHubAdminClientInner = () => {
                   ? "Disable Category"
                   : "Enable Category"
               }
+              shouldWrapChildren
             >
               <Switch
                 aria-label={

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
@@ -50,7 +50,10 @@ export default function HospitalityItemsMasonry({
                 </Tooltip>
               )}
               {onToggleActive && (
-                <Tooltip label={item.isActive ? "Disable Item" : "Enable Item"}>
+                <Tooltip
+                  label={item.isActive ? "Disable Item" : "Enable Item"}
+                  shouldWrapChildren
+                >
                   <Switch
                     aria-label={item.isActive ? "Disable Item" : "Enable Item"}
                     size="sm"


### PR DESCRIPTION
## Summary
- wrap Switch tooltips with `shouldWrapChildren` so that Chakra listens for hover events on disabled switches

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68498f88beec83269fcf51254c2e3b73