### PR TITLE
Introduce delay for Hospitality Hub admin tooltips

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -64,7 +64,7 @@ export const HospitalityHubAdminClientInner = () => {
                 </option>
               ))}
             </Select>
-            <Tooltip label="Add Category">
+            <Tooltip label="Add Category" openDelay={1000}>
               <IconButton
                 aria-label="Add Category"
                 icon={<FiPlus />}
@@ -76,7 +76,7 @@ export const HospitalityHubAdminClientInner = () => {
                 colorScheme="green"
               />
             </Tooltip>
-            <Tooltip label="Edit Category">
+            <Tooltip label="Edit Category" openDelay={1000}>
               <IconButton
                 aria-label="Edit Category"
                 icon={<FiEdit2 />}
@@ -91,7 +91,7 @@ export const HospitalityHubAdminClientInner = () => {
                 colorScheme="blue"
               />
             </Tooltip>
-            <Tooltip label="Delete Category">
+            <Tooltip label="Delete Category" openDelay={1000}>
               <IconButton
                 aria-label="Delete Category"
                 icon={<FiTrash2 />}
@@ -108,6 +108,7 @@ export const HospitalityHubAdminClientInner = () => {
                   : "Enable Category"
               }
               shouldWrapChildren
+              openDelay={1000}
             >
               <Switch
                 aria-label={

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
@@ -28,7 +28,7 @@ export default function HospitalityItemsMasonry({
           {(onEdit || onDelete || onToggleActive) && (
             <HStack position="absolute" top={2} right={2} spacing={1}>
               {onEdit && (
-                <Tooltip label="Edit Item">
+                <Tooltip label="Edit Item" openDelay={1000}>
                   <IconButton
                     aria-label="Edit Item"
                     size="sm"
@@ -39,7 +39,7 @@ export default function HospitalityItemsMasonry({
                 </Tooltip>
               )}
               {onDelete && (
-                <Tooltip label="Delete Item">
+                <Tooltip label="Delete Item" openDelay={1000}>
                   <IconButton
                     aria-label="Delete Item"
                     size="sm"
@@ -53,6 +53,7 @@ export default function HospitalityItemsMasonry({
                 <Tooltip
                   label={item.isActive ? "Disable Item" : "Enable Item"}
                   shouldWrapChildren
+                  openDelay={1000}
                 >
                   <Switch
                     aria-label={item.isActive ? "Disable Item" : "Enable Item"}


### PR DESCRIPTION
## Summary
- add 1s delay to category tooltips
- add 1s delay to item tooltips

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849914d4b648326bf3210680b54e0a8