### PR TITLE
Add toast notifications for Hospitality Hub admin

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -111,6 +111,14 @@ export default function AddCategoryModal({
       return;
     }
 
+    toast({
+      title: category ? "Category updated successfully." : "Category created successfully.",
+      status: "success",
+      duration: 5000,
+      isClosable: true,
+      position: "bottom-right",
+    });
+
     onCreated();
     reset();
     onClose();

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -176,6 +176,14 @@ export default function AddItemModal({
         return;
       }
 
+      toast({
+        title: item ? "Item updated successfully." : "Item created successfully.",
+        status: "success",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+
       onCreated();
       reset();
       setLogoFile(null);

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -67,6 +67,13 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
               });
               return;
             }
+            toast({
+              title: "Item updated successfully.",
+              status: "success",
+              duration: 5000,
+              isClosable: true,
+              position: "bottom-right",
+            });
             refresh();
           }}
         />

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteCategoryModal.tsx
@@ -58,6 +58,14 @@ export default function DeleteCategoryModal({
       return;
     }
 
+    toast({
+      title: "Category deleted successfully.",
+      status: "success",
+      duration: 5000,
+      isClosable: true,
+      position: "bottom-right",
+    });
+
     onDeleted();
     onClose();
   };

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/DeleteItemModal.tsx
@@ -49,6 +49,14 @@ export default function DeleteItemModal({
       return;
     }
 
+    toast({
+      title: "Item deleted successfully.",
+      status: "success",
+      duration: 5000,
+      isClosable: true,
+      position: "bottom-right",
+    });
+
     onDeleted();
     onClose();
   };

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -9,6 +9,7 @@ import {
   HStack,
   Tooltip,
   Switch,
+  useToast,
 } from "@chakra-ui/react";
 import {
   FiPlus,
@@ -31,6 +32,7 @@ export const HospitalityHubAdminClientInner = () => {
   const { categories, loading, refresh } = useHospitalityCategories();
   const [selectedCategory, setSelectedCategory] =
     useState<HospitalityCategory | null>(null);
+  const toast = useToast();
 
   useEffect(() => {
     if (!selectedCategory && categories.length > 0) {
@@ -139,10 +141,26 @@ export const HospitalityHubAdminClientInner = () => {
                     }),
                   });
                   if (res.ok) {
+                    toast({
+                      title: "Category updated successfully.",
+                      status: "success",
+                      duration: 5000,
+                      isClosable: true,
+                      position: "bottom-right",
+                    });
                     refresh();
                     setSelectedCategory({
                       ...selectedCategory,
                       isActive: !selectedCategory.isActive,
+                    });
+                  } else {
+                    const data = await res.json();
+                    toast({
+                      title: data.error || "Failed to update category.",
+                      status: "error",
+                      duration: 5000,
+                      isClosable: true,
+                      position: "bottom-right",
                     });
                   }
                 }}


### PR DESCRIPTION
## Summary
- notify user when creating or updating categories succeeds
- notify user when creating or updating items succeeds
- notify user when deleting items or categories succeeds
- show success or error toast when toggling item or category active state

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684993d67f548326a5ea4570ef10f36a