### PR TITLE
Update Hospitality Hub admin toolbar

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Spinner, VStack, Button, useToast } from "@chakra-ui/react";
+import { Spinner, VStack, useToast } from "@chakra-ui/react";
 import HospitalityItemsMasonry from "./HospitalityItemsMasonry";
 import { HospitalityCategory, HospitalityItem } from "@/types/hospitalityHub";
 import useHospitalityItems from "../../hooks/useHospitalityItems";
-import { useState } from "react";
+import { useState, forwardRef, useImperativeHandle } from "react";
 import AddItemModal from "./AddItemModal";
 import DeleteItemModal from "./DeleteItemModal";
 
@@ -12,7 +12,13 @@ interface CategoryTabContentProps {
   category: HospitalityCategory;
 }
 
-export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
+export interface CategoryTabContentRef {
+  openAddModal: () => void;
+}
+export const CategoryTabContent = forwardRef<
+  CategoryTabContentRef,
+  CategoryTabContentProps
+>(({ category }, ref) => {
   const { items, loading, refresh } = useHospitalityItems(category.id);
   const [modalOpen, setModalOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<HospitalityItem | null>(null);
@@ -22,21 +28,19 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
   );
   const toast = useToast();
 
+  useImperativeHandle(ref, () => ({
+    openAddModal: () => {
+      setEditingItem(null);
+      setModalOpen(true);
+    },
+  }));
+
   if (loading) {
     return <Spinner />;
   }
 
   return (
     <VStack w="100%" align="stretch" spacing={4}>
-      <Button
-        alignSelf="flex-end"
-        onClick={() => {
-          setEditingItem(null);
-          setModalOpen(true);
-        }}
-      >
-        Add Item
-      </Button>
       {loading ? (
         <Spinner />
       ) : (
@@ -93,6 +97,6 @@ export const CategoryTabContent = ({ category }: CategoryTabContentProps) => {
       />
     </VStack>
   );
-};
+});
 
 export default CategoryTabContent;

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   VStack,
   Spinner,
@@ -20,7 +20,7 @@ import {
 } from "react-icons/fi";
 import { HospitalityCategory } from "@/types/hospitalityHub";
 import useHospitalityCategories from "../../hooks/useHospitalityCategories";
-import CategoryTabContent from "./CategoryTabContent";
+import CategoryTabContent, { CategoryTabContentRef } from "./CategoryTabContent";
 import AddCategoryModal from "./AddCategoryModal";
 import DeleteCategoryModal from "./DeleteCategoryModal";
 
@@ -32,6 +32,7 @@ export const HospitalityHubAdminClientInner = () => {
   const { categories, loading, refresh } = useHospitalityCategories();
   const [selectedCategory, setSelectedCategory] =
     useState<HospitalityCategory | null>(null);
+  const itemTabRef = useRef<CategoryTabContentRef>(null);
   const toast = useToast();
 
   useEffect(() => {
@@ -80,6 +81,20 @@ export const HospitalityHubAdminClientInner = () => {
                 border="1px solid"
                 borderColor="green.400"
                 _hover={{ bg: "white", color: "green.400", borderColor: "green.400" }}
+              />
+            </Tooltip>
+            <Tooltip label="Add Item" openDelay={1000}>
+              <IconButton
+                aria-label="Add Item"
+                icon={<FiPlus />}
+                onClick={() => itemTabRef.current?.openAddModal()}
+                size="sm"
+                bg="green.400"
+                color="white"
+                border="1px solid"
+                borderColor="green.400"
+                _hover={{ bg: "white", color: "green.400", borderColor: "green.400" }}
+                isDisabled={!selectedCategory}
               />
             </Tooltip>
             <Tooltip label="Edit Category" openDelay={1000}>
@@ -170,7 +185,10 @@ export const HospitalityHubAdminClientInner = () => {
             </Tooltip>
           </HStack>
           {selectedCategory && (
-            <CategoryTabContent category={selectedCategory} />
+            <CategoryTabContent
+              ref={itemTabRef}
+              category={selectedCategory}
+            />
           )}
         </>
       )}


### PR DESCRIPTION
## Summary
- expose function to open item modal in `CategoryTabContent`
- remove Add Item button from the page content
- add Add Item icon button next to the category dropdown

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499a1d7844832694cff841ae122128