### PR TITLE
Improve hospitality admin UI updates

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
@@ -4,6 +4,7 @@ import { Box, HStack, IconButton, SimpleGrid, Tooltip, Switch } from "@chakra-ui
 import HospitalityItemCard from "../../components/HospitalityItemCard";
 import { HospitalityItem } from "@/types/hospitalityHub";
 import { FiEdit2, FiTrash2, FiToggleLeft, FiToggleRight } from "react-icons/fi";
+import { AnimatedList, AnimatedListItem } from "@/components/animations/AnimatedList";
 
 interface HospitalityItemsMasonryProps {
   items: HospitalityItem[];
@@ -22,59 +23,63 @@ export default function HospitalityItemsMasonry({
 }: HospitalityItemsMasonryProps) {
   return (
     <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
-      {items.map((item: HospitalityItem) => (
-        <Box key={item.id} position="relative">
-          <HospitalityItemCard item={item} optionalFields={optionalFields} />
-          {(onEdit || onDelete || onToggleActive) && (
-            <HStack position="absolute" top={2} right={2} spacing={1}>
-              {onEdit && (
-                <Tooltip label="Edit Item" openDelay={1000}>
-                  <IconButton
-                    aria-label="Edit Item"
-                    size="sm"
-                    icon={<FiEdit2 />}
-                    onClick={() => onEdit(item)}
-                    bg="blue.400"
-                    color="white"
-                    border="1px solid"
-                    borderColor="blue.400"
-                    _hover={{ bg: "white", color: "blue.400", borderColor: "blue.400" }}
-                  />
-                </Tooltip>
+      <AnimatedList>
+        {items.map((item: HospitalityItem, index) => (
+          <AnimatedListItem key={item.id} index={index}>
+            <Box position="relative">
+              <HospitalityItemCard item={item} optionalFields={optionalFields} />
+              {(onEdit || onDelete || onToggleActive) && (
+                <HStack position="absolute" top={2} right={2} spacing={1}>
+                  {onEdit && (
+                    <Tooltip label="Edit Item" openDelay={1000}>
+                      <IconButton
+                        aria-label="Edit Item"
+                        size="sm"
+                        icon={<FiEdit2 />}
+                        onClick={() => onEdit(item)}
+                        bg="blue.400"
+                        color="white"
+                        border="1px solid"
+                        borderColor="blue.400"
+                        _hover={{ bg: "white", color: "blue.400", borderColor: "blue.400" }}
+                      />
+                    </Tooltip>
+                  )}
+                  {onDelete && (
+                    <Tooltip label="Delete Item" openDelay={1000}>
+                      <IconButton
+                        aria-label="Delete Item"
+                        size="sm"
+                        icon={<FiTrash2 />}
+                        onClick={() => onDelete(item)}
+                        bg="red.400"
+                        color="white"
+                        border="1px solid"
+                        borderColor="red.400"
+                        _hover={{ bg: "white", color: "red.400", borderColor: "red.400" }}
+                      />
+                    </Tooltip>
+                  )}
+                  {onToggleActive && (
+                    <Tooltip
+                      label={item.isActive ? "Disable Item" : "Enable Item"}
+                      shouldWrapChildren
+                      openDelay={1000}
+                    >
+                      <Switch
+                        aria-label={item.isActive ? "Disable Item" : "Enable Item"}
+                        size="sm"
+                        isChecked={item.isActive}
+                        onChange={() => onToggleActive(item)}
+                      />
+                    </Tooltip>
+                  )}
+                </HStack>
               )}
-              {onDelete && (
-                <Tooltip label="Delete Item" openDelay={1000}>
-                  <IconButton
-                    aria-label="Delete Item"
-                    size="sm"
-                    icon={<FiTrash2 />}
-                    onClick={() => onDelete(item)}
-                    bg="red.400"
-                    color="white"
-                    border="1px solid"
-                    borderColor="red.400"
-                    _hover={{ bg: "white", color: "red.400", borderColor: "red.400" }}
-                  />
-                </Tooltip>
-              )}
-              {onToggleActive && (
-                <Tooltip
-                  label={item.isActive ? "Disable Item" : "Enable Item"}
-                  shouldWrapChildren
-                  openDelay={1000}
-                >
-                  <Switch
-                    aria-label={item.isActive ? "Disable Item" : "Enable Item"}
-                    size="sm"
-                    isChecked={item.isActive}
-                    onChange={() => onToggleActive(item)}
-                  />
-                </Tooltip>
-              )}
-            </HStack>
-          )}
-        </Box>
-      ))}
+            </Box>
+          </AnimatedListItem>
+        ))}
+      </AnimatedList>
     </SimpleGrid>
   );
 }


### PR DESCRIPTION
## Summary
- preserve the hospitality hub items list while refreshing
- animate hospitality hub item cards when adding or removing items
- update item active switch locally when toggled

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ace24eb0c8326a972457c9c6f2a3d