### PR TITLE
Improve hospitality hub item details

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -10,6 +10,8 @@ import {
   Text,
   Spinner,
   VStack,
+  Image,
+  SimpleGrid,
 } from "@chakra-ui/react";
 import { HospitalityItem } from "@/types/hospitalityHub";
 
@@ -40,14 +42,51 @@ export const ItemDetailModal = ({
           ) : (
             <VStack align="start" spacing={2}>
               {item?.description && <Text>{item.description}</Text>}
+              {item?.howToDetails && (
+                <Text>How To: {item.howToDetails}</Text>
+              )}
+              {item?.extraDetails && (
+                <Text>Extra Details: {item.extraDetails}</Text>
+              )}
+              {item?.startDate && (
+                <Text>Start Date: {item.startDate}</Text>
+              )}
+              {item?.endDate && <Text>End Date: {item.endDate}</Text>}
+              {item?.location && <Text>Location: {item.location}</Text>}
+              {item?.itemType && <Text>Item Type: {item.itemType}</Text>}
               {optionalFields?.map((field) =>
-                item && item[field] ? (
+                item && (item as any)[field] ? (
                   <Text key={field}>
                     {field.charAt(0).toUpperCase() + field.slice(1)}:{" "}
-                    {String(item[field])}
+                    {String((item as any)[field])}
                   </Text>
                 ) : null
               )}
+              {(item?.logoImageUrl || item?.coverImageUrl) && (
+                <SimpleGrid columns={[1, 2]} gap={2} w="100%">
+                  {item?.coverImageUrl && (
+                    <Image
+                      src={item.coverImageUrl}
+                      alt={item.name}
+                      borderRadius="md"
+                    />
+                  )}
+                  {item?.logoImageUrl && (
+                    <Image
+                      src={item.logoImageUrl}
+                      alt={item.name}
+                      borderRadius="md"
+                    />
+                  )}
+                </SimpleGrid>
+              )}
+              {item?.additionalImageUrlList?.length ? (
+                <SimpleGrid columns={[1, 2]} gap={2} w="100%">
+                  {item.additionalImageUrlList.map((url) => (
+                    <Image key={url} src={url} alt={item?.name} borderRadius="md" />
+                  ))}
+                </SimpleGrid>
+              ) : null}
             </VStack>
           )}
         </ModalBody>


### PR DESCRIPTION
## Summary
- update `ItemDetailModal` to render optional fields plus start/end dates, location and images

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684acf2159708326836d29d73a026d63