### PR TITLE
Improve Hospitality Hub Admin UI

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useState, useRef } from "react";
 import {
   VStack,
   Spinner,
@@ -10,6 +10,8 @@ import {
   Tooltip,
   Switch,
   useToast,
+  Text,
+  Center,
 } from "@chakra-ui/react";
 import {
   FiPlus,
@@ -36,20 +38,18 @@ export const HospitalityHubAdminClientInner = () => {
   const itemTabRef = useRef<CategoryTabContentRef>(null);
   const toast = useToast();
 
-  useEffect(() => {
-    if (!selectedCategory && categories.length > 0) {
-      setSelectedCategory(categories[0]);
-    }
-  }, [categories, selectedCategory]);
-
   return (
-    <VStack w="100%" spacing={4} align="stretch">
+    <VStack w="100%" spacing={4} align="stretch" flex={1} py={4}>
+      <Text fontFamily="bonfire" fontSize="3xl" textAlign="center" color="white">
+        Hospitality Hub Admin
+      </Text>
       {loading ? (
         <Spinner />
       ) : (
         <>
           <HStack>
             <Select
+              placeholder="Select Category"
               value={selectedCategory?.id?.toString() || ""}
               onChange={(e) => {
                 const value = e.target.value;
@@ -185,11 +185,22 @@ export const HospitalityHubAdminClientInner = () => {
               />
             </Tooltip>
           </HStack>
-          {selectedCategory && (
+          {selectedCategory ? (
             <CategoryTabContent
               ref={itemTabRef}
               category={selectedCategory}
             />
+          ) : (
+            <Center flex={1}>
+              <Text
+                fontFamily="bonfire"
+                fontSize="2xl"
+                textAlign="center"
+                color="white"
+              >
+                select a category to start!
+              </Text>
+            </Center>
           )}
         </>
       )}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/page.tsx
@@ -1,10 +1,10 @@
-import { Center } from "@chakra-ui/react";
+import { PerygonContainer } from "@/components/layout/PerygonContainer";
 import { HospitalityHubAdminClientInner } from "./components/HospitalityHubAdminClientInner";
 
 export default function HospitalityHubAdminPage() {
   return (
-    <Center minH="100vh" w="100%" p={4}>
+    <PerygonContainer>
       <HospitalityHubAdminClientInner />
-    </Center>
+    </PerygonContainer>
   );
 }


### PR DESCRIPTION
## Summary
- use Perygon container for Hospitality Hub admin page
- show heading and placeholder text in bonfire font
- leave category unselected by default

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad38dd50483269a343b57f32760fe