### PR TITLE
Add handler email to hospitality hub admin forms

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -30,6 +30,7 @@ interface AddCategoryModalProps {
 interface FormValues {
   name: string;
   description: string;
+  handlerEmail?: string;
   customerId?: number;
   catOwnerUserId?: number;
   imageUrl?: string;
@@ -67,10 +68,12 @@ export default function AddCategoryModal({
       if (category) {
         setValue("name", category.name);
         setValue("description", category.description);
+        setValue("handlerEmail", category.handlerEmail || "");
         setImageUrl(category.imageUrl || "");
       } else {
         reset();
         setImageUrl("");
+        setValue("handlerEmail", "");
         if (customerId !== undefined) setValue("customerId", customerId);
         if (userId !== undefined) setValue("catOwnerUserId", userId);
       }
@@ -141,6 +144,10 @@ export default function AddCategoryModal({
             <FormControl mb={4} isRequired>
               <FormLabel>Description</FormLabel>
               <Input {...register("description", { required: true })} />
+            </FormControl>
+            <FormControl mb={4}>
+              <FormLabel>Handler Email</FormLabel>
+              <Input {...register("handlerEmail")} type="email" />
             </FormControl>
             <FormControl mb={4}>
               <FormLabel>Image</FormLabel>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -36,6 +36,7 @@ interface FormValues {
   startDate: string;
   endDate: string;
   location: string;
+  handlerEmail?: string;
   customerId?: number;
   itemOwnerUserId?: number;
   logoImageUrl?: string;
@@ -94,6 +95,7 @@ export default function AddItemModal({
         setValue("description", item.description);
         setValue("howToDetails", item.howToDetails);
         setValue("extraDetails", item.extraDetails);
+        setValue("handlerEmail", item.handlerEmail || "");
         setValue("startDate", item.startDate ? item.startDate.slice(0, 10) : "");
         setValue("endDate", item.endDate ? item.endDate.slice(0, 10) : "");
         setValue("location", item.location);
@@ -105,6 +107,7 @@ export default function AddItemModal({
         setLogoUrl("");
         setCoverUrl("");
         setAdditionalUrls([]);
+        setValue("handlerEmail", "");
         if (customerId !== undefined) setValue("customerId", customerId);
         if (userId !== undefined) setValue("itemOwnerUserId", userId);
       }
@@ -242,6 +245,10 @@ export default function AddItemModal({
             <FormControl mb={4}>
               <FormLabel>Location</FormLabel>
               <Input {...register("location")} />
+            </FormControl>
+            <FormControl mb={4}>
+              <FormLabel>Handler Email</FormLabel>
+              <Input {...register("handlerEmail")} type="email" />
             </FormControl>
             <FormControl mb={4}>
               <FormLabel>Logo Image</FormLabel>

--- a/src/types/hospitalityHub.ts
+++ b/src/types/hospitalityHub.ts
@@ -15,6 +15,7 @@ export interface HospitalityItem {
   logoImageUrl: string;
   coverImageUrl: string;
   additionalImageUrlList: string[];
+  handlerEmail?: string;
 }
 
 export interface HospitalityCategory {
@@ -25,4 +26,5 @@ export interface HospitalityCategory {
   catOwnerUserId: string;
   isActive: boolean;
   imageUrl?: string;
+  handlerEmail?: string;
 }


### PR DESCRIPTION
## Summary
- allow category and item forms to collect a handler email
- track the handler email in hospitality hub types

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bdd2f13548326abfc313b07758c2b