### PR TITLE
Update hospitality hub masonry layout

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -71,7 +71,12 @@ export function HospitalityHubMasonry({
         >
           <Text fontWeight="bold">&larr; Back</Text>
         </Box>
-        <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
+        {/* use an auto-fill grid so cards make use of the available width */}
+        <SimpleGrid
+          w="100%"
+          gap={4}
+          templateColumns="repeat(auto-fill, minmax(250px, 1fr))"
+        >
           <AnimatedList>
             {items.map((item, index) => (
               <AnimatedListItem key={item.id} index={index}>
@@ -108,7 +113,12 @@ export function HospitalityHubMasonry({
   }
 
   return (
-    <SimpleGrid columns={[2, 3, 5]} gap={4} w="100%">
+    {/* categories grid also uses auto-fill to utilize available width */}
+    <SimpleGrid
+      w="100%"
+      gap={4}
+      templateColumns="repeat(auto-fill, minmax(250px, 1fr))"
+    >
       <AnimatedList>
         {categories.map((category, index) => (
           <AnimatedListItem key={category.id} index={index}>


### PR DESCRIPTION
## Summary
- improve item and category grids so they use available width

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684be2d0ea9083269e8b0a0c7dde8cb8