### PR TITLE
Update Hospitality Hub item masonry

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 import { AnimatedList, AnimatedListItem } from "@/components/animations/AnimatedList";
 import { useState } from "react";
-import HospitalityItemCard from "../../components/HospitalityItemCard";
+import HospitalityItemsMasonry from "./HospitalityItemsMasonry";
 import ItemDetailModal from "./ItemDetailModal";
 import { HospitalityItem } from '@/types/hospitalityHub';
 import useHospitalityItems from "../../hooks/useHospitalityItems";
@@ -71,22 +71,13 @@ export function HospitalityHubMasonry({
         >
           <Text fontWeight="bold">&larr; Back</Text>
         </Box>
-        <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
-          <AnimatedList>
-            {items.map((item, index) => (
-              <AnimatedListItem key={item.id} index={index}>
-                <HospitalityItemCard
-                  item={item}
-                  optionalFields={
-                    categories.find((c) => c.id === selected)?.optionalFields || []
-                  }
-                  onClick={() => handleItemClick(item.id)}
-                  showOverlay
-                />
-              </AnimatedListItem>
-            ))}
-          </AnimatedList>
-        </SimpleGrid>
+        <HospitalityItemsMasonry
+          items={items}
+          optionalFields={
+            categories.find((c) => c.id === selected)?.optionalFields || []
+          }
+          onItemClick={(item) => handleItemClick(item.id)}
+        />
         <ItemDetailModal
           isOpen={modalOpen}
           onClose={() => {

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityItemsMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityItemsMasonry.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Box, SimpleGrid } from "@chakra-ui/react";
+import { AnimatedList, AnimatedListItem } from "@/components/animations/AnimatedList";
+import HospitalityItemCard from "../../components/HospitalityItemCard";
+import { HospitalityItem } from "@/types/hospitalityHub";
+
+interface HospitalityItemsMasonryProps {
+  items: HospitalityItem[];
+  optionalFields?: string[];
+  onItemClick?: (item: HospitalityItem) => void;
+}
+
+export default function HospitalityItemsMasonry({
+  items,
+  optionalFields = [],
+  onItemClick,
+}: HospitalityItemsMasonryProps) {
+  return (
+    <SimpleGrid columns={[1, 2, 3]} gap={4} w="100%">
+      <AnimatedList>
+        {items.map((item, index) => (
+          <AnimatedListItem key={item.id} index={index}>
+            <Box position="relative">
+              <HospitalityItemCard
+                item={item}
+                optionalFields={optionalFields}
+                showOverlay
+                onClick={() => onItemClick?.(item)}
+              />
+            </Box>
+          </AnimatedListItem>
+        ))}
+      </AnimatedList>
+    </SimpleGrid>
+  );
+}


### PR DESCRIPTION
## Summary
- create `HospitalityItemsMasonry` for displaying items
- use `HospitalityItemsMasonry` in `HospitalityHubMasonry` to match admin layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be5a5a97083269ebc0c54f1365445