### PR TITLE
Add disabled overlay to Hospitality Hub items

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityItemsMasonry.tsx
@@ -46,6 +46,7 @@ export default function HospitalityItemsMasonry({
               <HospitalityItemCard
                 item={item}
                 optionalFields={optionalFields}
+                disabled={!item.isActive}
               />
               {(onEdit || onDelete || onToggleActive) && (
                 <HStack position="absolute" top={2} right={2} spacing={1}>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/components/HospitalityItemCard.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/components/HospitalityItemCard.tsx
@@ -8,6 +8,11 @@ export interface HospitalityItemCardProps {
   optionalFields?: string[];
   onClick?: () => void;
   showOverlay?: boolean;
+  /**
+   * When true the card displays a semi-transparent overlay to
+   * visually indicate that the item is disabled.
+   */
+  disabled?: boolean;
 }
 
 function formatLabel(label: string) {
@@ -19,6 +24,7 @@ export default function HospitalityItemCard({
   optionalFields = [],
   onClick,
   showOverlay,
+  disabled = false,
 }: HospitalityItemCardProps) {
   return (
     <Box
@@ -55,6 +61,18 @@ export default function HospitalityItemCard({
           )}
         </VStack>
       </PerygonCard>
+      {disabled && (
+        <Box
+          position="absolute"
+          top={0}
+          left={0}
+          w="100%"
+          h="100%"
+          bg="rgba(128,128,128,0.5)"
+          borderRadius="inherit"
+          pointerEvents="none"
+        />
+      )}
       {showOverlay && (
         <Box
           position="absolute"


### PR DESCRIPTION
## Summary
- show grey overlay when Hospitality Hub items are disabled
- pass disabled flag from admin masonry to item card

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffcbbd9e08326bf3e501f9ec9ab18