### PR TITLE
fix hospitality hub uploads

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -110,7 +110,10 @@ export default function AddItemModal({
     }
 
     try {
-      const method = item ? "PUT" : "POST";
+      // Always use POST for file uploads. The backend
+      // switches between create and update based on the
+      // presence of an `id` field.
+      const method = "POST";
       const formData = new FormData();
 
       Object.entries(data).forEach(([key, value]) => {

--- a/src/app/api/hospitality-hub/items/route.ts
+++ b/src/app/api/hospitality-hub/items/route.ts
@@ -53,6 +53,7 @@ export async function POST(req: NextRequest) {
 
     if (contentType.includes("multipart/form-data")) {
       const incoming = await req.formData();
+      const id = incoming.get("id");
       const laravelFormData = new FormData();
       incoming.forEach((value, key) => {
         if (value instanceof Blob) {
@@ -62,7 +63,11 @@ export async function POST(req: NextRequest) {
         }
       });
 
-      response = await fetch(`${process.env.BE_URL}/userHospitalityItem`, {
+      const url = id
+        ? `${process.env.BE_URL}/userHospitalityItem/${id}`
+        : `${process.env.BE_URL}/userHospitalityItem`;
+
+      response = await fetch(url, {
         method: "POST",
         headers: {
           Authorization: authToken ? `Bearer ${authToken}` : "",
@@ -71,7 +76,11 @@ export async function POST(req: NextRequest) {
       });
     } else {
       const payload = await req.json();
-      response = await fetch(`${process.env.BE_URL}/userHospitalityItem`, {
+      const id = payload?.id;
+      const url = id
+        ? `${process.env.BE_URL}/userHospitalityItem/${id}`
+        : `${process.env.BE_URL}/userHospitalityItem`;
+      response = await fetch(url, {
         method: "POST",
         headers: {
           Authorization: authToken ? `Bearer ${authToken}` : "",


### PR DESCRIPTION
## Summary
- always use POST for Hospitality Hub item uploads
- support POST updates in the backend route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685030221c4483269d0b8e503cba0237