### PR TITLE
Add client-side image cropping for hospitality hub uploads

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -18,6 +18,7 @@ import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
 import { useToast } from "@chakra-ui/react";
 import { useMediaUploader } from "@/hooks/useMediaUploader";
+import ImageCropper from "@/components/forms/ImageCropper";
 import { HospitalityCategory } from "@/types/hospitalityHub";
 
 interface AddCategoryModalProps {
@@ -48,11 +49,14 @@ export default function AddCategoryModal({
   const { user } = useUser();
 
   const [imageUrl, setImageUrl] = useState<string>("");
+  const [cropFile, setCropFile] = useState<File | null>(null);
+  const [isCropOpen, setCropOpen] = useState(false);
 
   const { uploadMediaFile, isUploading } = useMediaUploader(
     "/api/hospitality-hub/uploadImage",
     "imageUrl",
     () => {},
+    10 * 1024 * 1024,
   );
 
   const customerId = user?.customerId;
@@ -154,11 +158,11 @@ export default function AddCategoryModal({
               <Input
                 type="file"
                 accept="image/*"
-                onChange={async (e) => {
+                onChange={(e) => {
                   const file = e.target.files?.[0];
                   if (!file) return;
-                  const data = await uploadMediaFile(file);
-                  setImageUrl(data.imageUrl);
+                  setCropFile(file);
+                  setCropOpen(true);
                   e.target.value = "";
                 }}
                 disabled={isUploading}
@@ -173,5 +177,15 @@ export default function AddCategoryModal({
         </form>
       </ModalContent>
     </Modal>
+    <ImageCropper
+      file={cropFile}
+      isOpen={isCropOpen}
+      onClose={() => setCropOpen(false)}
+      onComplete={async (f) => {
+        const data = await uploadMediaFile(f);
+        setImageUrl(data.imageUrl);
+        setCropOpen(false);
+      }}
+    />
   );
 }

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -20,6 +20,7 @@ import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
 import { useToast } from "@chakra-ui/react";
 import { HospitalityItem } from "@/types/hospitalityHub";
+import ImageCropper from "@/components/forms/ImageCropper";
 
 interface AddItemModalProps {
   isOpen: boolean;
@@ -58,6 +59,9 @@ export default function AddItemModal({
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [coverFile, setCoverFile] = useState<File | null>(null);
   const [additionalFiles, setAdditionalFiles] = useState<File[]>([]);
+  const [cropFile, setCropFile] = useState<File | null>(null);
+  const [cropTarget, setCropTarget] = useState<"logo" | "cover" | null>(null);
+  const [isCropOpen, setCropOpen] = useState(false);
 
   const customerId = user?.customerId;
   const userId = user?.userId;
@@ -235,7 +239,11 @@ export default function AddItemModal({
                 accept="image/*"
                 onChange={(e) => {
                   const file = e.target.files?.[0] || null;
-                  setLogoFile(file);
+                  if (!file) return;
+                  setCropFile(file);
+                  setCropTarget("logo");
+                  setCropOpen(true);
+                  e.target.value = "";
                 }}
               />
             </FormControl>
@@ -246,7 +254,11 @@ export default function AddItemModal({
                 accept="image/*"
                 onChange={(e) => {
                   const file = e.target.files?.[0] || null;
-                  setCoverFile(file);
+                  if (!file) return;
+                  setCropFile(file);
+                  setCropTarget("cover");
+                  setCropOpen(true);
+                  e.target.value = "";
                 }}
               />
             </FormControl>
@@ -271,5 +283,15 @@ export default function AddItemModal({
         </form>
       </ModalContent>
     </Modal>
+    <ImageCropper
+      file={cropFile}
+      isOpen={isCropOpen}
+      onClose={() => setCropOpen(false)}
+      onComplete={(f) => {
+        if (cropTarget === "logo") setLogoFile(f);
+        if (cropTarget === "cover") setCoverFile(f);
+        setCropOpen(false);
+      }}
+    />
   );
 }

--- a/src/components/forms/ImageCropper.tsx
+++ b/src/components/forms/ImageCropper.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react";
+
+interface ImageCropperProps {
+  file: File | null;
+  isOpen: boolean;
+  onComplete: (file: File) => void;
+  onClose: () => void;
+  /** Target width for the final image */
+  targetWidth?: number;
+  /** Target height for the final image */
+  targetHeight?: number;
+}
+
+export default function ImageCropper({
+  file,
+  isOpen,
+  onComplete,
+  onClose,
+  targetWidth = 800,
+  targetHeight = 800,
+}: ImageCropperProps) {
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [imgUrl, setImgUrl] = useState<string>("");
+  const cropSize = 300; // square crop box
+  const [cropPos, setCropPos] = useState({ x: 0, y: 0 });
+  const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    setImgUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [file]);
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setDragStart({ x: e.clientX - cropPos.x, y: e.clientY - cropPos.y });
+  };
+
+  const onMouseMove = (e: React.MouseEvent) => {
+    if (!dragStart) return;
+    e.preventDefault();
+    const cont = containerRef.current;
+    if (!cont) return;
+    let newX = e.clientX - dragStart.x;
+    let newY = e.clientY - dragStart.y;
+    const maxX = cont.clientWidth - cropSize;
+    const maxY = cont.clientHeight - cropSize;
+    if (newX < 0) newX = 0;
+    if (newY < 0) newY = 0;
+    if (newX > maxX) newX = maxX;
+    if (newY > maxY) newY = maxY;
+    setCropPos({ x: newX, y: newY });
+  };
+
+  const onMouseUp = () => setDragStart(null);
+
+  const handleCrop = async () => {
+    if (!imgRef.current || !file) return;
+    const img = imgRef.current;
+    const scaleX = img.naturalWidth / img.clientWidth;
+    const scaleY = img.naturalHeight / img.clientHeight;
+    const canvas = document.createElement("canvas");
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(
+      img,
+      cropPos.x * scaleX,
+      cropPos.y * scaleY,
+      cropSize * scaleX,
+      cropSize * scaleY,
+      0,
+      0,
+      targetWidth,
+      targetHeight,
+    );
+
+    let quality = 0.92;
+    let blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob((b) => resolve(b), "image/jpeg", quality),
+    );
+    while (blob && blob.size > 10 * 1024 * 1024 && quality > 0.2) {
+      quality -= 0.1;
+      blob = await new Promise((resolve) =>
+        canvas.toBlob((b) => resolve(b), "image/jpeg", quality),
+      );
+    }
+    if (!blob) return;
+    const croppedFile = new File(
+      [blob],
+      file.name.replace(/\.[^.]+$/, ".jpg"),
+      {
+        type: "image/jpeg",
+      },
+    );
+    onComplete(croppedFile);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl" isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Crop Image</ModalHeader>
+        <ModalBody>
+          {imgUrl && (
+            <Box position="relative" ref={containerRef} userSelect="none">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imgUrl}
+                alt="to crop"
+                ref={imgRef}
+                style={{ maxWidth: "100%", height: "auto" }}
+                onMouseMove={onMouseMove}
+                onMouseUp={onMouseUp}
+                onMouseLeave={onMouseUp}
+              />
+              <Box
+                position="absolute"
+                top={`${cropPos.y}px`}
+                left={`${cropPos.x}px`}
+                width={`${cropSize}px`}
+                height={`${cropSize}px`}
+                border="2px dashed #fff"
+                cursor="move"
+                onMouseDown={onMouseDown}
+              />
+            </Box>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose} variant="ghost">
+            Cancel
+          </Button>
+          <Button colorScheme="blue" onClick={handleCrop}>
+            Crop
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `ImageCropper` component for simple drag-to-crop functionality
- apply cropping in Hospitality Hub admin category and item modals
- ensure uploads are compressed below 10 MB

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503bcdd3e0832692f8730376c1a91e