### PR TITLE
Add basic image cropping

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -54,6 +54,7 @@ export default function AddCategoryModal({
     "/api/hospitality-hub/uploadImage",
     "imageUrl",
     () => {},
+    10 * 1024 * 1024,
   );
 
   const customerId = user?.customerId;

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -14,6 +14,7 @@ import {
   FormLabel,
   Input,
 } from "@chakra-ui/react";
+import ImageUploadWithCrop from "@/components/image/ImageUploadWithCrop";
 import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
 import { useToast } from "@chakra-ui/react";
@@ -49,7 +50,7 @@ export default function AddCategoryModal({
 
   const [imageUrl, setImageUrl] = useState<string>("");
 
-  const { uploadMediaFile, isUploading } = useMediaUploader(
+  const { uploadMediaFile } = useMediaUploader(
     "/api/hospitality-hub/uploadImage",
     "imageUrl",
     () => {},
@@ -149,21 +150,14 @@ export default function AddCategoryModal({
               <FormLabel>Handler Email</FormLabel>
               <Input {...register("handlerEmail")} type="email" />
             </FormControl>
-            <FormControl mb={4}>
-              <FormLabel>Image</FormLabel>
-              <Input
-                type="file"
-                accept="image/*"
-                onChange={async (e) => {
-                  const file = e.target.files?.[0];
-                  if (!file) return;
-                  const data = await uploadMediaFile(file);
-                  setImageUrl(data.imageUrl);
-                  e.target.value = "";
-                }}
-                disabled={isUploading}
-              />
-            </FormControl>
+            <ImageUploadWithCrop
+              label="Image"
+              onFileSelected={async (file) => {
+                if (!file) return;
+                const data = await uploadMediaFile(file);
+                setImageUrl(data.imageUrl);
+              }}
+            />
           </ModalBody>
           <ModalFooter>
             <Button type="submit" colorScheme="blue">

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -16,6 +16,7 @@ import {
   Textarea,
   Select,
 } from "@chakra-ui/react";
+import ImageUploadWithCrop from "@/components/image/ImageUploadWithCrop";
 import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
 import { useToast } from "@chakra-ui/react";
@@ -228,28 +229,14 @@ export default function AddItemModal({
               <FormLabel>Handler Email</FormLabel>
               <Input {...register("handlerEmail")} type="email" />
             </FormControl>
-            <FormControl mb={4}>
-              <FormLabel>Logo Image</FormLabel>
-              <Input
-                type="file"
-                accept="image/*"
-                onChange={(e) => {
-                  const file = e.target.files?.[0] || null;
-                  setLogoFile(file);
-                }}
-              />
-            </FormControl>
-            <FormControl mb={4}>
-              <FormLabel>Cover Image</FormLabel>
-              <Input
-                type="file"
-                accept="image/*"
-                onChange={(e) => {
-                  const file = e.target.files?.[0] || null;
-                  setCoverFile(file);
-                }}
-              />
-            </FormControl>
+            <ImageUploadWithCrop
+              label="Logo Image"
+              onFileSelected={(file) => setLogoFile(file)}
+            />
+            <ImageUploadWithCrop
+              label="Cover Image"
+              onFileSelected={(file) => setCoverFile(file)}
+            />
             <FormControl mb={4}>
               <FormLabel>Additional Images</FormLabel>
               <Input

--- a/src/components/image/ImageCropper.tsx
+++ b/src/components/image/ImageCropper.tsx
@@ -1,0 +1,199 @@
+import React, { useRef, useState, useEffect } from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+} from "@chakra-ui/react";
+
+interface Crop {
+  x: number;
+  y: number;
+  size: number;
+}
+
+interface ImageCropperProps {
+  file: File | null;
+  isOpen: boolean;
+  onComplete: (file: File) => void;
+  onCancel: () => void;
+}
+
+// Utility to create File from canvas content
+const canvasToFile = async (
+  canvas: HTMLCanvasElement,
+  fileName: string,
+  type = "image/jpeg",
+): Promise<File> => {
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => {
+      resolve(new File([blob!], fileName, { type }));
+    }, type, 0.9);
+  });
+};
+
+export default function ImageCropper({
+  file,
+  isOpen,
+  onComplete,
+  onCancel,
+}: ImageCropperProps) {
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [imgUrl, setImgUrl] = useState<string>("");
+  const [crop, setCrop] = useState<Crop>({ x: 10, y: 10, size: 80 });
+  const [dragging, setDragging] = useState<boolean>(false);
+  const [resizing, setResizing] = useState<boolean>(false);
+  const [start, setStart] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  useEffect(() => {
+    if (file) {
+      setImgUrl(URL.createObjectURL(file));
+    } else {
+      setImgUrl("");
+    }
+  }, [file]);
+
+  const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setStart({ x: e.clientX, y: e.clientY });
+    const target = e.target as HTMLElement;
+    if (target.dataset.type === "resize") {
+      setResizing(true);
+    } else {
+      setDragging(true);
+    }
+  };
+
+  const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!dragging && !resizing) return;
+    const dx = e.clientX - start.x;
+    const dy = e.clientY - start.y;
+    setStart({ x: e.clientX, y: e.clientY });
+    setCrop((c) => {
+      if (!containerRef.current) return c;
+      const rect = containerRef.current.getBoundingClientRect();
+      const maxX = 100;
+      const maxY = 100;
+      if (resizing) {
+        let newSize = c.size + ((dx + dy) / rect.width) * 100;
+        newSize = Math.max(10, Math.min(newSize, 100));
+        return { ...c, size: newSize };
+      }
+      let newX = c.x + (dx / rect.width) * 100;
+      let newY = c.y + (dy / rect.height) * 100;
+      newX = Math.max(0, Math.min(newX, maxX - c.size));
+      newY = Math.max(0, Math.min(newY, maxY - c.size));
+      return { ...c, x: newX, y: newY };
+    });
+  };
+
+  const onMouseUp = () => {
+    setDragging(false);
+    setResizing(false);
+  };
+
+  const handleComplete = async () => {
+    if (!imgRef.current || !file) return;
+    const img = imgRef.current;
+    const canvas = document.createElement("canvas");
+    const scaleX = img.naturalWidth / img.width;
+    const scaleY = img.naturalHeight / img.height;
+    const sx = (crop.x / 100) * img.naturalWidth;
+    const sy = (crop.y / 100) * img.naturalHeight;
+    const sSize = (crop.size / 100) * img.naturalWidth;
+    canvas.width = sSize;
+    canvas.height = sSize;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.drawImage(
+        img,
+        sx,
+        sy,
+        sSize,
+        sSize,
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+      );
+    }
+    let newFile = await canvasToFile(canvas, file.name, file.type);
+    // ensure <10MB
+    let quality = 0.9;
+    while (newFile.size > 10 * 1024 * 1024 && quality > 0.1) {
+      quality -= 0.1;
+      newFile = await new Promise<File>((resolve) => {
+        canvas.toBlob((blob) => {
+          resolve(new File([blob!], file.name, { type: file.type }));
+        }, file.type, quality);
+      });
+    }
+    onComplete(newFile);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel} size="xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Crop Image</ModalHeader>
+        <ModalBody>
+          {imgUrl && (
+            <div
+              ref={containerRef}
+              style={{ position: "relative", width: "100%", height: 400 }}
+              onMouseMove={onMouseMove}
+              onMouseUp={onMouseUp}
+              onMouseLeave={onMouseUp}
+            >
+              <img
+                ref={imgRef}
+                src={imgUrl}
+                alt="crop"
+                style={{ width: "100%", height: "100%", objectFit: "contain" }}
+              />
+              <div
+                onMouseDown={onMouseDown}
+                style={{
+                  border: "2px solid #fff",
+                  position: "absolute",
+                  left: `${crop.x}%`,
+                  top: `${crop.y}%`,
+                  width: `${crop.size}%`,
+                  height: `${crop.size}%`,
+                  cursor: dragging ? "grabbing" : "grab",
+                }}
+              >
+                <div
+                  data-type="resize"
+                  style={{
+                    position: "absolute",
+                    width: 10,
+                    height: 10,
+                    right: -5,
+                    bottom: -5,
+                    background: "#fff",
+                    cursor: "nwse-resize",
+                  }}
+                  onMouseDown={onMouseDown}
+                />
+              </div>
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button colorScheme="blue" onClick={handleComplete}>
+            Crop
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+

--- a/src/components/image/ImageUploadWithCrop.tsx
+++ b/src/components/image/ImageUploadWithCrop.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { FormControl, FormLabel, Input } from "@chakra-ui/react";
+import ImageCropper from "./ImageCropper";
+
+interface Props {
+  label: string;
+  onFileSelected: (file: File | null) => void;
+  isRequired?: boolean;
+}
+
+export default function ImageUploadWithCrop({
+  label,
+  onFileSelected,
+  isRequired = false,
+}: Props) {
+  const [file, setFile] = useState<File | null>(null);
+  const [cropOpen, setCropOpen] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) {
+      setFile(f);
+      setCropOpen(true);
+    }
+    e.target.value = "";
+  };
+
+  const handleComplete = (cropped: File) => {
+    setCropOpen(false);
+    setFile(null);
+    onFileSelected(cropped);
+  };
+
+  const handleCancel = () => {
+    setCropOpen(false);
+    setFile(null);
+  };
+
+  return (
+    <FormControl mb={4} isRequired={isRequired}>
+      <FormLabel>{label}</FormLabel>
+      <Input type="file" accept="image/*" onChange={handleChange} />
+      <ImageCropper
+        file={file}
+        isOpen={cropOpen}
+        onCancel={handleCancel}
+        onComplete={handleComplete}
+      />
+    </FormControl>
+  );
+}

--- a/src/components/image/ImageUploadWithCrop.tsx
+++ b/src/components/image/ImageUploadWithCrop.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FormControl, FormLabel, Input } from "@chakra-ui/react";
+import { FormControl, FormLabel, Input, Image } from "@chakra-ui/react";
 import ImageCropper from "./ImageCropper";
 
 interface Props {
@@ -15,6 +15,7 @@ export default function ImageUploadWithCrop({
 }: Props) {
   const [file, setFile] = useState<File | null>(null);
   const [cropOpen, setCropOpen] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string>("");
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0];
@@ -28,6 +29,7 @@ export default function ImageUploadWithCrop({
   const handleComplete = (cropped: File) => {
     setCropOpen(false);
     setFile(null);
+    setPreviewUrl(URL.createObjectURL(cropped));
     onFileSelected(cropped);
   };
 
@@ -40,6 +42,9 @@ export default function ImageUploadWithCrop({
     <FormControl mb={4} isRequired={isRequired}>
       <FormLabel>{label}</FormLabel>
       <Input type="file" accept="image/*" onChange={handleChange} />
+      {previewUrl && (
+        <Image src={previewUrl} alt="preview" maxH="100px" mt={2} />
+      )}
       <ImageCropper
         file={file}
         isOpen={cropOpen}


### PR DESCRIPTION
## Summary
- add ImageCropper component using canvas
- add ImageUploadWithCrop wrapper to integrate cropping
- allow cropping in hospitality hub's category and item modals

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68503bcdd3e0832692f8730376c1a91e