### PR TITLE
Add drag and drop image uploads for hospitality hub

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -17,6 +17,7 @@ import {
   Select,
 } from "@chakra-ui/react";
 import ImageUploadWithCrop from "@/components/image/ImageUploadWithCrop";
+import DragDropFileInput from "@/components/forms/DragDropFileInput";
 import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
 import { useToast } from "@chakra-ui/react";
@@ -239,14 +240,10 @@ export default function AddItemModal({
             />
             <FormControl mb={4}>
               <FormLabel>Additional Images</FormLabel>
-              <Input
-                type="file"
+              <DragDropFileInput
                 multiple
-                accept="image/*"
-                onChange={(e) => {
-                  const files = Array.from(e.target.files || []);
-                  setAdditionalFiles(files);
-                }}
+                placeholder="Drag & drop additional images here"
+                onFilesSelected={(files) => setAdditionalFiles(files)}
               />
             </FormControl>
           </ModalBody>

--- a/src/components/forms/DragDropFileInput.tsx
+++ b/src/components/forms/DragDropFileInput.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import React, { useState, useRef, useCallback } from "react";
+import {
+  Box,
+  VStack,
+  Image,
+  Text,
+  Button,
+  useColorModeValue,
+} from "@chakra-ui/react";
+
+interface DragDropFileInputProps {
+  onFilesSelected: (files: File[]) => void;
+  placeholder?: string;
+  multiple?: boolean;
+}
+
+export default function DragDropFileInput({
+  onFilesSelected,
+  placeholder = "Drag & drop files here",
+  multiple = false,
+}: DragDropFileInputProps) {
+  const [previewUrl, setPreviewUrl] = useState<string>("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const borderColor = useColorModeValue("gray.400", "gray.600");
+  const hoverBorderColor = useColorModeValue("gray.200", "gray.400");
+
+  const handleFiles = (files: FileList | File[]) => {
+    const arr = Array.from(files);
+    if (!multiple && arr[0]) {
+      setPreviewUrl(URL.createObjectURL(arr[0]));
+    }
+    onFilesSelected(arr);
+  };
+
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const files = e.dataTransfer.files;
+      if (files && files.length > 0) {
+        handleFiles(files);
+      }
+    },
+    []
+  );
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      handleFiles(files);
+    }
+    e.target.value = "";
+  };
+
+  return (
+    <VStack w="100%" align="center" spacing={4}>
+      <Box
+        w="100%"
+        maxW="400px"
+        p={6}
+        border="2px dashed"
+        background="rgba(255, 255, 255, 0.1)"
+        borderColor={borderColor}
+        borderRadius="md"
+        textAlign="center"
+        position="relative"
+        cursor="pointer"
+        _hover={{ borderColor: hoverBorderColor }}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+      >
+        <Box mb={4}>
+          {previewUrl && !multiple ? (
+            <Image src={previewUrl} alt="preview" maxH="100px" mx="auto" />
+          ) : (
+            <Text color="white" fontSize={18}>
+              {placeholder}
+            </Text>
+          )}
+        </Box>
+        <Button
+          size="sm"
+          colorScheme="blue"
+          mt={previewUrl && !multiple ? 0 : 4}
+          onClick={(e) => {
+            e.stopPropagation();
+            inputRef.current?.click();
+          }}
+        >
+          {previewUrl && !multiple ? "Change File" : "Browse files"}
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple={multiple}
+          style={{ display: "none" }}
+          onChange={onFileChange}
+        />
+      </Box>
+    </VStack>
+  );
+}

--- a/src/components/image/ImageUploadWithCrop.tsx
+++ b/src/components/image/ImageUploadWithCrop.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import { FormControl, FormLabel, Input, Image } from "@chakra-ui/react";
+import { useState, useRef, useCallback } from "react";
+import {
+  FormControl,
+  FormLabel,
+  VStack,
+  Box,
+  Button,
+  Text,
+  Image,
+  useColorModeValue,
+} from "@chakra-ui/react";
 import ImageCropper from "./ImageCropper";
 
 interface Props {
@@ -18,12 +27,37 @@ export default function ImageUploadWithCrop({
   const [file, setFile] = useState<File | null>(null);
   const [cropOpen, setCropOpen] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string>("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const borderColor = useColorModeValue("gray.400", "gray.600");
+  const hoverBorderColor = useColorModeValue("gray.200", "gray.400");
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0];
+  const handleFiles = (files: FileList | File[]) => {
+    const f = files[0];
     if (f) {
       setFile(f);
       setCropOpen(true);
+    }
+  };
+
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const files = e.dataTransfer.files;
+      if (files && files.length > 0) {
+        handleFiles(files);
+      }
+    },
+    []
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      handleFiles(files);
     }
     e.target.value = "";
   };
@@ -43,10 +77,52 @@ export default function ImageUploadWithCrop({
   return (
     <FormControl mb={4} isRequired={isRequired}>
       <FormLabel>{label}</FormLabel>
-      <Input type="file" accept="image/*" onChange={handleChange} />
-      {previewUrl && (
-        <Image src={previewUrl} alt="preview" maxH="100px" mt={2} />
-      )}
+      <VStack w="100%" align="center" spacing={4}>
+        <Box
+          w="100%"
+          maxW="400px"
+          p={6}
+          border="2px dashed"
+          background="rgba(255, 255, 255, 0.1)"
+          borderColor={borderColor}
+          borderRadius="md"
+          textAlign="center"
+          position="relative"
+          cursor="pointer"
+          _hover={{ borderColor: hoverBorderColor }}
+          onClick={() => inputRef.current?.click()}
+          onDragOver={onDragOver}
+          onDrop={onDrop}
+        >
+          <Box mb={4}>
+            {previewUrl ? (
+              <Image src={previewUrl} alt="preview" maxH="100px" mx="auto" />
+            ) : (
+              <Text color="white" fontSize={18}>
+                Drag & drop image here
+              </Text>
+            )}
+          </Box>
+          <Button
+            size="sm"
+            colorScheme="blue"
+            mt={previewUrl ? 0 : 4}
+            onClick={(e) => {
+              e.stopPropagation();
+              inputRef.current?.click();
+            }}
+          >
+            {previewUrl ? "Change Image" : "Browse files"}
+          </Button>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={handleChange}
+          />
+        </Box>
+      </VStack>
       <ImageCropper
         file={file}
         isOpen={cropOpen}


### PR DESCRIPTION
## Summary
- add reusable DragDropFileInput component for drag/drop selection
- convert hospitality hub item modal to use new input
- update ImageUploadWithCrop with drag/drop UI

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68504d34721083268cb56f3539c4448a