### PR TITLE
Improve Hospitality Hub card hover

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/MasonryItemCard.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/MasonryItemCard.tsx
@@ -1,7 +1,17 @@
 "use client";
 import { Box, Text, Image } from "@chakra-ui/react";
+import { keyframes } from "@emotion/react";
 import { HospitalityItem } from "@/types/hospitalityHub";
 import PerygonCard from "@/components/layout/PerygonCard";
+
+const shimmer = keyframes`
+  0% {
+    transform: translateX(-100%) skewX(-20deg);
+  }
+  100% {
+    transform: translateX(100%) skewX(-20deg);
+  }
+`;
 
 export interface MasonryItemCardProps {
   item: HospitalityItem;
@@ -16,6 +26,7 @@ export default function MasonryItemCard({
 }: MasonryItemCardProps) {
   return (
     <PerygonCard
+      role="group"
       position="relative"
       borderRadius="lg"
       h="100%"
@@ -23,7 +34,7 @@ export default function MasonryItemCard({
       onClick={onClick}
       overflow="hidden"
       transition="transform 0.3s, box-shadow 0.3s"
-      _hover={{ transform: "scale(1.03)", boxShadow: "3xl" }}
+      _hover={{ transform: "scale(1.05)", boxShadow: "4xl" }}
       p={0}
     >
       {(item.coverImageUrl || item.logoImageUrl) && (
@@ -35,6 +46,22 @@ export default function MasonryItemCard({
           h="100%"
         />
       )}
+      {/* Shimmer overlay */}
+      <Box
+        position="absolute"
+        top={0}
+        left={0}
+        w="150%"
+        h="100%"
+        pointerEvents="none"
+        bgGradient="linear(120deg, transparent 0%, rgba(255,255,255,0.5) 50%, transparent 100%)"
+        transform="translateX(-100%) skewX(-20deg)"
+        opacity={0}
+        _groupHover={{ opacity: 1, animation: `${shimmer} 0.8s` }}
+        onAnimationEnd={(e) => {
+          (e.target as HTMLElement).style.animation = "none";
+        }}
+      />
       <Box
         position="absolute"
         display="flex"
@@ -45,6 +72,7 @@ export default function MasonryItemCard({
         w="100%"
         p={8}
         h="50%"
+        pointerEvents="none"
         bgGradient="linear(to-t, rgba(0,0,0,0.9), rgba(0,0,0,0))"
       >
         <Text
@@ -52,11 +80,20 @@ export default function MasonryItemCard({
           fontWeight="bold"
           fontSize={["lg", "2xl", null, null, null, "4xl"]}
           fontFamily="metropolis"
+          transition="transform 0.3s"
+          _groupHover={{ transform: "translateY(-10px)" }}
         >
           {item.name}
         </Text>
         {item.description && (
-          <Text color="white" fontSize="sm">
+          <Text
+            color="white"
+            fontSize="sm"
+            opacity={0}
+            transform="translateY(10px)"
+            transition="opacity 0.3s, transform 0.3s"
+            _groupHover={{ opacity: 1, transform: "translateY(0)" }}
+          >
             {item.description}
           </Text>
         )}


### PR DESCRIPTION
## Summary
- make hospitality hub masonry card use group hover
- animate title and description on hover
- scale and shadow card on hover
- add shimmer animation overlay

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685142a108148326ad2f553b4f9265ce