### PR TITLE
Add logo overlay to hospitality hub cards

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/MasonryItemCard.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/MasonryItemCard.tsx
@@ -54,6 +54,16 @@ export default function MasonryItemCard({
           h="100%"
         />
       )}
+      {item.logoImageUrl && (
+        <Box position="absolute" top={2} right={2} zIndex={1} pointerEvents="none">
+          <Image
+            src={item.logoImageUrl}
+            alt={`${item.name} logo`}
+            boxSize="50px"
+            objectFit="contain"
+          />
+        </Box>
+      )}
       {/* Shimmer overlay */}
       <Box
         position="absolute"


### PR DESCRIPTION
## Summary
- show logo image in the top-right corner of hospitality hub masonry cards

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514a7363588326bf004739800aa633