### PR TITLE
Add premium color to themes and use in hospitality hub shimmer

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/MasonryItemCard.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/MasonryItemCard.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { Box, Text, Image } from "@chakra-ui/react";
+import { Box, Text, Image, useTheme } from "@chakra-ui/react";
+import { transparentize } from "@chakra-ui/theme-tools";
 import { keyframes } from "@emotion/react";
 import { HospitalityItem } from "@/types/hospitalityHub";
 import PerygonCard from "@/components/layout/PerygonCard";
@@ -32,6 +33,8 @@ export default function MasonryItemCard({
   onClick,
   disabled = false,
 }: MasonryItemCardProps) {
+  const theme = useTheme();
+  const shimmerColor = transparentize(theme.colors.premium, 0.5)(theme);
   return (
     <PerygonCard
       role="group"
@@ -62,7 +65,7 @@ export default function MasonryItemCard({
         w="150%"
         h="100%"
         pointerEvents="none"
-        bgGradient="linear(120deg, transparent 0%, rgba(255,255,255,0.5) 50%, transparent 100%)"
+        bgGradient={`linear(120deg, transparent 0%, ${shimmerColor} 50%, transparent 100%)`}
         transform="translateX(-100%) skewX(-20deg)"
         opacity={0}
         _groupHover={{ animation: `${shimmer} 0.8s` }}

--- a/src/theme/themes/base-theme/baseTheme.ts
+++ b/src/theme/themes/base-theme/baseTheme.ts
@@ -33,6 +33,7 @@ export const baseTheme = extendTheme({
     yellow: "#EFC718",
     lightGreen: "#92C01F",
     seduloGreen: "#008000",
+    premium: "#a5917f",
     darkGray: "#4A4A4A",
     darkElementBG: "rgb(41, 41, 41, 0.85)",
     primaryTextColor: "rgb(0, 0, 0)",

--- a/src/theme/themes/clients/DMR/dmrDefaultTheme.ts
+++ b/src/theme/themes/clients/DMR/dmrDefaultTheme.ts
@@ -5,6 +5,7 @@ import { baseTheme } from "../../base-theme/baseTheme";
 const colorPalette = {
   dmrPrimary: "hsla(205, 31%, 26%, 1)",
   dmrSecondary: "hsla( 72, 98%, 64%, 1)",
+  premium: "#a9ab50",
 };
 
 const gradients = {
@@ -22,6 +23,7 @@ export const dmrDefaultTheme = extendTheme(baseTheme, {
     primaryButton: colorPalette.dmrSecondary,
     elementBG: "rgb(255, 255, 255)",
     elementBG2: "hsla( 72, 98%, 64%, 1)",
+    premium: colorPalette.premium,
     primaryTextColor: "rgb(0, 0, 0)",
     secondaryTextColor: "rgb(83, 83, 83)",
     themeTextColor: colorPalette.dmrPrimary,

--- a/src/theme/themes/clients/prByWhitney/prByWhitneyTheme.ts
+++ b/src/theme/themes/clients/prByWhitney/prByWhitneyTheme.ts
@@ -7,6 +7,7 @@ const colorPalette = {
   prByWhitneySecondary: "white",
   prByWhitneyPebble: "rgb(243, 243, 243)",
   prByWhitneyHighlight: "rgb(239, 114, 39)",
+  premium: "#a59126",
 };
 
 const gradients = {
@@ -22,6 +23,7 @@ export const prByWhitneyDefaultTheme = extendTheme(baseTheme, {
     primaryButton: colorPalette.prByWhitneySecondary,
     elementBG: "rgb(255, 255, 255)",
     elementBG2: colorPalette.prByWhitneyPrimary,
+    premium: colorPalette.premium,
     primaryTextColor: "rgb(0, 0, 0)",
     secondaryTextColor: "rgb(83, 83, 83)",
     themeTextColor: colorPalette.prByWhitneyHighlight,

--- a/src/theme/themes/perygon/perygonMinimal/colorPalette.ts
+++ b/src/theme/themes/perygon/perygonMinimal/colorPalette.ts
@@ -6,4 +6,5 @@ export const colorPalette = {
   yellow: "#EFC718",
   lightGreen: "#92C01F",
   seduloGreen: "#008000",
+  premium: "#c4b045",
 };

--- a/src/theme/themes/perygon/perygonMinimal/perygonMinimalDark.ts
+++ b/src/theme/themes/perygon/perygonMinimal/perygonMinimalDark.ts
@@ -12,6 +12,7 @@ export const MinimalDark = extendTheme(baseTheme, {
     elementBG: "rgb(48, 48, 48)",
     elementBG2: "rgb(78, 78, 78)",
     shadowColor: "red",
+    premium: colorPalette.premium,
     primaryTextColor: "rgb(255, 255, 255)",
     secondaryTextColor: "rgb(255, 255, 255)",
     themeTextColor: "rgb(255, 255, 255)",

--- a/src/theme/themes/perygon/perygonMoonlight/colorPalette.ts
+++ b/src/theme/themes/perygon/perygonMoonlight/colorPalette.ts
@@ -6,4 +6,5 @@ export const colorPalette = {
   yellow: "#EFC718",
   lightGreen: "#92C01F",
   seduloGreen: "#008000",
+  premium: "#c4b045",
 };

--- a/src/theme/themes/perygon/perygonMoonlight/perygonMoonlight.ts
+++ b/src/theme/themes/perygon/perygonMoonlight/perygonMoonlight.ts
@@ -13,6 +13,7 @@ export const Moonlight = extendTheme(baseTheme, {
     elementBG: "rgb(48, 48, 48)",
     elementBG2: "rgb(78, 78, 78)",
     shadowColor: "red",
+    premium: colorPalette.premium,
     primaryTextColor: "rgb(212, 212, 212)",
     secondaryTextColor: "rgb(230, 230, 230)",
     themeTextColor: "rgb(155, 155, 155)",

--- a/src/theme/themes/perygon/perygonNeonSedulo/NeonSeduloTheme.ts
+++ b/src/theme/themes/perygon/perygonNeonSedulo/NeonSeduloTheme.ts
@@ -13,6 +13,7 @@ export const NeonSedulo = extendTheme(baseTheme, {
     elementBG: "rgb(46, 46, 46)",
     elementBG2: "rgb(90, 11, 11)",
     shadowColor: "red",
+    premium: colorPalette.premium,
     primaryTextColor: "rgb(165, 165, 165)",
     secondaryTextColor: "rgb(145, 145, 145)",
     themeTextColor: "rgba(255, 0, 0, 0.85)",

--- a/src/theme/themes/perygon/perygonNeonSedulo/colorPalette.ts
+++ b/src/theme/themes/perygon/perygonNeonSedulo/colorPalette.ts
@@ -6,4 +6,5 @@ export const colorPalette = {
   yellow: "#EFC718",
   lightGreen: "#92C01F",
   seduloGreen: "#008000",
+  premium: "#f6891d",
 };

--- a/src/theme/themes/perygon/perygonTheme/colorPalette.ts
+++ b/src/theme/themes/perygon/perygonTheme/colorPalette.ts
@@ -6,4 +6,5 @@ export const colorPalette = {
   yellow: "#EFC718",
   lightGreen: "#92C01F",
   seduloGreen: "#008000",
+  premium: "#fe914d",
 };

--- a/src/theme/themes/perygon/perygonTheme/perygonTheme.ts
+++ b/src/theme/themes/perygon/perygonTheme/perygonTheme.ts
@@ -14,6 +14,7 @@ export const perygonTheme = extendTheme(baseTheme, {
     elementBG2: "rgb(255, 223, 251)",
     elementBGTransparent: "rgb(255, 223, 251, 0.3)",
     shadowColor: "red",
+    premium: colorPalette.premium,
     primaryTextColor: "rgb(0, 0, 0)",
     secondaryTextColor: "rgb(83, 83, 83)",
     themeTextColor: colorPalette.perygonPink,

--- a/src/theme/themes/perygon/perygonThemeBlue/colorPalette.ts
+++ b/src/theme/themes/perygon/perygonThemeBlue/colorPalette.ts
@@ -5,6 +5,7 @@ export const colorPalette = {
 
   yellow: "#EFC718",
   lightGreen: "#92C01F",
+  premium: "#a7a87a",
   happinessScale: {
     1: "#b22200",
     2: "#e92300",

--- a/src/theme/themes/perygon/perygonThemeBlue/perygonThemeBlue.ts
+++ b/src/theme/themes/perygon/perygonThemeBlue/perygonThemeBlue.ts
@@ -18,6 +18,7 @@ export const perygonThemeBlue = extendTheme(baseTheme, {
     primaryButton: colorPalette.perygonPurple,
     elementBG: "rgb(255, 255, 255)",
     elementBG2: "rgb(191, 211, 255)",
+    premium: colorPalette.premium,
     primaryTextColor: "rgb(0, 0, 0)",
     secondaryTextColor: "rgb(83, 83, 83)",
     themeTextColor: colorPalette.perygonBlue,


### PR DESCRIPTION
## Summary
- introduce `premium` color into base theme and all custom themes
- apply premium color to the Hospitality Hub masonry card shimmer

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_68514b4541a08326b66a68895f4935db