### PR TITLE
Add constant gradient for Hospitality Hub app

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/MasonryItemCard.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/MasonryItemCard.tsx
@@ -42,6 +42,7 @@ export default function MasonryItemCard({
       onClick={onClick}
       overflow="hidden"
       transition="transform 0.3s, box-shadow 0.3s"
+      border="3px solid rgb(238, 228, 88)"
       _hover={{ transform: "scale(1.05)", boxShadow: "4xl" }}
       p={0}
     >
@@ -97,7 +98,7 @@ export default function MasonryItemCard({
         bgGradient="linear(to-t, rgba(0,0,0,0.9), rgba(0,0,0,0))"
       >
         <Text
-          color="white"
+          color="rgb(238, 228, 88)"
           fontWeight="bold"
           fontSize={["lg", "2xl", null, null, null, "4xl"]}
           fontFamily="metropolis"

--- a/src/components/layout/PerygonContainer.tsx
+++ b/src/components/layout/PerygonContainer.tsx
@@ -18,7 +18,7 @@ export const PerygonContainer: React.FC<PerygonContatinerProps> = ({
 
   const pathname = usePathname();
 
-  const hospitalityHubGradient = "linear(to-br, black 0%, gold 100%)";
+  const hospitalityHubGradient = "linear(to-br, black 60%, gray 100%)";
 
   const displayBackgroundImage = () => {
     if (headerBackgroundImageUrl && pathname.includes("workflow")) {

--- a/src/components/layout/PerygonContainer.tsx
+++ b/src/components/layout/PerygonContainer.tsx
@@ -18,6 +18,8 @@ export const PerygonContainer: React.FC<PerygonContatinerProps> = ({
 
   const pathname = usePathname();
 
+  const hospitalityHubGradient = "linear(to-br, black 0%, gold 100%)";
+
   const displayBackgroundImage = () => {
     if (headerBackgroundImageUrl && pathname.includes("workflow")) {
       return headerBackgroundImageUrl;
@@ -29,7 +31,11 @@ export const PerygonContainer: React.FC<PerygonContatinerProps> = ({
       minH="100svh"
       width="100%"
       flex={1}
-      bgGradient={theme.components.perygonContainer.baseStyle.bgGradient}
+      bgGradient={
+        pathname.startsWith("/hospitality-hub/app")
+          ? hospitalityHubGradient
+          : theme.components.perygonContainer.baseStyle.bgGradient
+      }
       bgImage={displayBackgroundImage()}
     >
       {children}


### PR DESCRIPTION
## Summary
- ensure the Hospitality Hub app always has a black to gold diagonal background

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515a2fbf788326a676e0e79ee09939