### PR TITLE
Update hospitality item modal background

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -52,7 +52,31 @@ export const ItemDetailModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="lg">
       <ModalOverlay />
-      <ModalContent bg="gray.800" color="gray.200" p={4}>
+      <ModalContent
+        position="relative"
+        color="gray.200"
+        p={4}
+        bg={item?.coverImageUrl ? undefined : "gray.800"}
+        backgroundImage={
+          item?.coverImageUrl
+            ? `linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)), url(${item.coverImageUrl})`
+            : undefined
+        }
+        backgroundSize="cover"
+        backgroundPosition="center"
+      >
+        {item?.logoImageUrl && (
+          <Image
+            src={item.logoImageUrl}
+            alt={item.name}
+            position="absolute"
+            top={2}
+            left={2}
+            boxSize="50px"
+            objectFit="contain"
+            borderRadius="md"
+          />
+        )}
         <ModalHeader
           fontSize="3xl"
           textAlign="center"


### PR DESCRIPTION
## Summary
- set item modal background to cover image with dark gradient
- show logo in top left corner

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515bad42608326ac51e0a9b6622a80