### PR TITLE
Improve hospitality hub item detail loading

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -40,13 +40,13 @@ export function HospitalityHubMasonry({
 
   const handleItemClick = async (itemId: string) => {
     if (!selected) return;
-    setModalOpen(true);
     setModalLoading(true);
     try {
       const res = await fetch(`/api/hospitality-hub/items?id=${itemId}`);
       const data = await res.json();
       if (res.ok) {
         setSelectedItem(data.resource);
+        setModalOpen(true);
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- fetch item details before opening the modal so it immediately displays data

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68527cab377c8326b817664333c4e7ea