### PR TITLE
Add user search autocomplete for hospitality hub owners

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -15,11 +15,12 @@ import {
   Input,
 } from "@chakra-ui/react";
 import ImageUploadWithCrop from "@/components/image/ImageUploadWithCrop";
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { useEffect, useState } from "react";
 import { useToast } from "@chakra-ui/react";
 import { useMediaUploader } from "@/hooks/useMediaUploader";
 import { HospitalityCategory } from "@/types/hospitalityHub";
+import UserSearchAutocomplete, { AutocompleteUser } from "@/components/forms/UserSearchAutocomplete";
 
 interface AddCategoryModalProps {
   isOpen: boolean;
@@ -148,8 +149,20 @@ export default function AddCategoryModal({
               <Input {...register("description", { required: true })} />
             </FormControl>
             <FormControl mb={4}>
-              <FormLabel>Handler Email</FormLabel>
-              <Input {...register("handlerEmail")} type="email" />
+              <FormLabel>Owner Email</FormLabel>
+              <Controller
+                name="handlerEmail"
+                control={control}
+                render={({ field: { value } }) => (
+                  <UserSearchAutocomplete
+                    value={value}
+                    onSelect={(u: AutocompleteUser) => {
+                      setValue("handlerEmail", u.email);
+                      setValue("catOwnerUserId", u.id);
+                    }}
+                  />
+                )}
+              />
             </FormControl>
             <ImageUploadWithCrop
               label="Image"

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -18,10 +18,11 @@ import {
 } from "@chakra-ui/react";
 import ImageUploadWithCrop from "@/components/image/ImageUploadWithCrop";
 import DragDropFileInput from "@/components/forms/DragDropFileInput";
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { useEffect, useState } from "react";
 import { useToast } from "@chakra-ui/react";
 import { HospitalityItem } from "@/types/hospitalityHub";
+import UserSearchAutocomplete, { AutocompleteUser } from "@/components/forms/UserSearchAutocomplete";
 
 interface AddItemModalProps {
   isOpen: boolean;
@@ -227,8 +228,20 @@ export default function AddItemModal({
               <Input {...register("location")} />
             </FormControl>
             <FormControl mb={4}>
-              <FormLabel>Handler Email</FormLabel>
-              <Input {...register("handlerEmail")} type="email" />
+              <FormLabel>Owner Email</FormLabel>
+              <Controller
+                name="handlerEmail"
+                control={control}
+                render={({ field: { value } }) => (
+                  <UserSearchAutocomplete
+                    value={value}
+                    onSelect={(u: AutocompleteUser) => {
+                      setValue("handlerEmail", u.email);
+                      setValue("itemOwnerUserId", u.id);
+                    }}
+                  />
+                )}
+              />
             </FormControl>
             <ImageUploadWithCrop
               label="Logo Image"

--- a/src/components/forms/UserSearchAutocomplete.tsx
+++ b/src/components/forms/UserSearchAutocomplete.tsx
@@ -1,0 +1,132 @@
+import React, { FC, useState, useEffect, useMemo, useCallback, ChangeEvent } from "react";
+import { Box, Input, HStack, Avatar, Text } from "@chakra-ui/react";
+import debounce from "lodash/debounce";
+import { AnimatedList, AnimatedListItem } from "@/components/animations/AnimatedList";
+import { useUser } from "@/providers/UserProvider";
+
+export interface AutocompleteUser {
+  id: number;
+  fullName: string;
+  email: string;
+  imageUrl?: string;
+}
+
+interface UserSearchAutocompleteProps {
+  value?: string;
+  onSelect: (user: AutocompleteUser) => void;
+  placeholder?: string;
+}
+
+const UserSearchAutocomplete: FC<UserSearchAutocompleteProps> = ({
+  value = "",
+  onSelect,
+  placeholder = "Type to search...",
+}) => {
+  const { user } = useUser();
+  const [search, setSearch] = useState(value);
+  const [options, setOptions] = useState<AutocompleteUser[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  const fetchUsers = useCallback(
+    debounce(async (query: string) => {
+      if (!query.trim() || !user?.customerId) {
+        setOptions([]);
+        return;
+      }
+      try {
+        const res = await fetch(
+          `/api/user/allBy?customerId=${user.customerId}&search=${encodeURIComponent(
+            query,
+          )}&selectColumns=id,fullName,email,imageUrl`,
+        );
+        const data = await res.json();
+        if (res.ok) {
+          setOptions(data.resource || []);
+        } else {
+          setOptions([]);
+          console.error(data.error || "Failed to fetch users");
+        }
+      } catch (err) {
+        console.error(err);
+        setOptions([]);
+      }
+    }, 300),
+    [user?.customerId],
+  );
+
+  useEffect(() => {
+    fetchUsers(search);
+    return () => {
+      fetchUsers.cancel();
+    };
+  }, [search, fetchUsers]);
+
+  useEffect(() => {
+    setSearch(value);
+  }, [value]);
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
+    setShowDropdown(true);
+  };
+
+  const handleSelect = (u: AutocompleteUser) => {
+    setSearch(u.fullName);
+    onSelect(u);
+    setShowDropdown(false);
+  };
+
+  return (
+    <Box position="relative">
+      <Input
+        placeholder={placeholder}
+        value={search}
+        onChange={handleInputChange}
+        onFocus={() => setShowDropdown(true)}
+        bg="elementBG"
+        color="primary"
+        borderColor="primary"
+        _hover={{ borderColor: "primary" }}
+        _focus={{ color: "primary" }}
+      />
+      {showDropdown && options.length > 0 && (
+        <Box
+          position="absolute"
+          top="100%"
+          left={0}
+          right={0}
+          bg="elementBG"
+          border="1px solid"
+          borderColor="primary"
+          borderTop="none"
+          zIndex={999}
+          maxHeight={300}
+          overflowY="auto"
+        >
+          <AnimatedList>
+            {options.map((option, index) => (
+              <AnimatedListItem key={option.id} index={index}>
+                <Box
+                  px={3}
+                  py={2}
+                  cursor="pointer"
+                  _hover={{ bg: "rgba(255, 20, 147, 0.1)" }}
+                  onMouseDown={() => handleSelect(option)}
+                >
+                  <HStack>
+                    <Avatar name={option.fullName} src={option.imageUrl} size="sm" />
+                    <Text color="primary" ml={2}>
+                      {option.fullName} ({option.email})
+                    </Text>
+                  </HStack>
+                </Box>
+              </AnimatedListItem>
+            ))}
+          </AnimatedList>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default UserSearchAutocomplete;


### PR DESCRIPTION
## Summary
- implement `UserSearchAutocomplete` component for searching users by name
- replace owner email fields in hospitality hub admin with the new search component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529832aac48326b33fb15abe0aacab