### PR TITLE
Add remove buttons for hospitality images

### DIFF
--- a/src/components/forms/DragDropFileInput.tsx
+++ b/src/components/forms/DragDropFileInput.tsx
@@ -22,6 +22,7 @@ export default function DragDropFileInput({
   multiple = false,
 }: DragDropFileInputProps) {
   const [previewUrl, setPreviewUrl] = useState<string>("");
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
   const borderColor = useColorModeValue("gray.400", "gray.600");
   const hoverBorderColor = useColorModeValue("gray.200", "gray.400");
@@ -31,6 +32,7 @@ export default function DragDropFileInput({
     if (!multiple && arr[0]) {
       setPreviewUrl(URL.createObjectURL(arr[0]));
     }
+    setSelectedFiles(arr);
     onFilesSelected(arr);
   };
 
@@ -38,16 +40,13 @@ export default function DragDropFileInput({
     e.preventDefault();
   }, []);
 
-  const onDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      const files = e.dataTransfer.files;
-      if (files && files.length > 0) {
-        handleFiles(files);
-      }
-    },
-    []
-  );
+  const onDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    const files = e.dataTransfer.files;
+    if (files && files.length > 0) {
+      handleFiles(files);
+    }
+  }, []);
 
   const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -55,6 +54,13 @@ export default function DragDropFileInput({
       handleFiles(files);
     }
     e.target.value = "";
+  };
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPreviewUrl("");
+    setSelectedFiles([]);
+    onFilesSelected([]);
   };
 
   return (
@@ -95,6 +101,11 @@ export default function DragDropFileInput({
         >
           {previewUrl && !multiple ? "Change File" : "Browse files"}
         </Button>
+        {(previewUrl || selectedFiles.length > 0) && (
+          <Button size="sm" colorScheme="red" ml={2} onClick={handleRemove}>
+            Remove
+          </Button>
+        )}
         <input
           ref={inputRef}
           type="file"

--- a/src/components/forms/DragDropFileInput.tsx
+++ b/src/components/forms/DragDropFileInput.tsx
@@ -7,8 +7,10 @@ import {
   Image,
   Text,
   Button,
+  IconButton,
   useColorModeValue,
 } from "@chakra-ui/react";
+import CloseIcon from "@mui/icons-material/Close";
 
 interface DragDropFileInputProps {
   onFilesSelected: (files: File[]) => void;
@@ -81,6 +83,19 @@ export default function DragDropFileInput({
         onDragOver={onDragOver}
         onDrop={onDrop}
       >
+        {(previewUrl || selectedFiles.length > 0) && (
+          <IconButton
+            aria-label="Remove"
+            icon={<CloseIcon />}
+            size="sm"
+            color="red.500"
+            variant="ghost"
+            position="absolute"
+            top={2}
+            right={2}
+            onClick={handleRemove}
+          />
+        )}
         <Box mb={4}>
           {previewUrl && !multiple ? (
             <Image src={previewUrl} alt="preview" maxH="100px" mx="auto" />
@@ -101,11 +116,6 @@ export default function DragDropFileInput({
         >
           {previewUrl && !multiple ? "Change File" : "Browse files"}
         </Button>
-        {(previewUrl || selectedFiles.length > 0) && (
-          <Button size="sm" colorScheme="red" ml={2} onClick={handleRemove}>
-            Remove
-          </Button>
-        )}
         <input
           ref={inputRef}
           type="file"

--- a/src/components/image/ImageUploadWithCrop.tsx
+++ b/src/components/image/ImageUploadWithCrop.tsx
@@ -71,6 +71,13 @@ export default function ImageUploadWithCrop({
     setFile(null);
   };
 
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPreviewUrl("");
+    setFile(null);
+    onFileSelected(null);
+  };
+
   return (
     <FormControl mb={4} isRequired={isRequired}>
       <FormLabel>{label}</FormLabel>
@@ -111,6 +118,11 @@ export default function ImageUploadWithCrop({
           >
             {previewUrl ? "Change Image" : "Browse files"}
           </Button>
+          {previewUrl && (
+            <Button size="sm" colorScheme="red" ml={2} onClick={handleRemove}>
+              Remove
+            </Button>
+          )}
           <input
             ref={inputRef}
             type="file"

--- a/src/components/image/ImageUploadWithCrop.tsx
+++ b/src/components/image/ImageUploadWithCrop.tsx
@@ -9,8 +9,10 @@ import {
   Button,
   Text,
   Image,
+  IconButton,
   useColorModeValue,
 } from "@chakra-ui/react";
+import CloseIcon from "@mui/icons-material/Close";
 import ImageCropper from "./ImageCropper";
 
 interface Props {
@@ -98,6 +100,19 @@ export default function ImageUploadWithCrop({
           onDragOver={onDragOver}
           onDrop={onDrop}
         >
+          {previewUrl && (
+            <IconButton
+              aria-label="Remove"
+              icon={<CloseIcon />}
+              size="sm"
+              color="red.500"
+              variant="ghost"
+              position="absolute"
+              top={2}
+              right={2}
+              onClick={handleRemove}
+            />
+          )}
           <Box mb={4}>
             {previewUrl ? (
               <Image src={previewUrl} alt="preview" maxH="100px" mx="auto" />
@@ -118,11 +133,6 @@ export default function ImageUploadWithCrop({
           >
             {previewUrl ? "Change Image" : "Browse files"}
           </Button>
-          {previewUrl && (
-            <Button size="sm" colorScheme="red" ml={2} onClick={handleRemove}>
-              Remove
-            </Button>
-          )}
           <input
             ref={inputRef}
             type="file"


### PR DESCRIPTION
## Summary
- add ability to clear selected image in `ImageUploadWithCrop`
- add removal support to `DragDropFileInput`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852997b838c8326bc786e9db533bf71