### PR TITLE
Filter inactive hospitality categories and items

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/page.tsx
@@ -14,7 +14,8 @@ export default async function HospitalityHubPage() {
     });
     const data = await res.json();
     if (res.ok) {
-      initialCategories = data.resource || [];
+      const fetched: HospitalityCategory[] = data.resource || [];
+      initialCategories = fetched.filter((cat) => cat.isActive);
     }
   } catch (err) {
     console.error("Failed to fetch categories", err);

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityCategories.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityCategories.ts
@@ -2,7 +2,9 @@ import { useState, useEffect } from "react";
 import { HospitalityCategory } from "@/types/hospitalityHub";
 
 export function useHospitalityCategories(initialCategories: HospitalityCategory[] = []) {
-  const [categories, setCategories] = useState<HospitalityCategory[]>(initialCategories);
+  const [categories, setCategories] = useState<HospitalityCategory[]>(
+    initialCategories.filter((c) => c.isActive),
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -12,7 +14,8 @@ export function useHospitalityCategories(initialCategories: HospitalityCategory[
       const res = await fetch('/api/hospitality-hub/categories');
       const data = await res.json();
       if (res.ok) {
-        setCategories(data.resource || []);
+        const fetched: HospitalityCategory[] = data.resource || [];
+        setCategories(fetched.filter((cat) => cat.isActive));
       } else {
         throw new Error(data?.error || 'Failed to fetch categories');
       }

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityItems.ts
@@ -15,7 +15,8 @@ export function useHospitalityItems(categoryKey?: string | null) {
       );
       const data = await res.json();
       if (res.ok) {
-        setItems(data.resource || []);
+        const fetched: HospitalityItem[] = data.resource || [];
+        setItems(fetched.filter((item) => item.isActive));
       } else {
         throw new Error(data?.error || "Failed to fetch items");
       }


### PR DESCRIPTION
## Summary
- filter out inactive categories and items in hospitality hub
- only pass active categories to masonry

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68529da75a288326934bcce3fd021c02