### PR TITLE
Fix info item CTA

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -65,13 +65,15 @@ export const ItemDetailModal = ({
   const [bookingOpen, setBookingOpen] = useState(false);
 
   const ctaText =
-    item?.itemType === "singleDayBookable"
-      ? "Book Now"
-      : item?.itemType === "singleDayBookableWithStartEnd"
-        ? "Book Slot"
-        : item?.itemType === "multiDayBookable"
-          ? "Book Event"
-          : "";
+    item?.itemType === "info"
+      ? ""
+      : item?.itemType === "singleDayBookable"
+        ? "Book Now"
+        : item?.itemType === "singleDayBookableWithStartEnd"
+          ? "Book Slot"
+          : item?.itemType === "multiDayBookable"
+            ? "Book Event"
+            : "";
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="4xl">


### PR DESCRIPTION
## Summary
- hide call-to-action button when an item's type is `info`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852d39fa8788326b1f02f7949819fba