### PR TITLE
Show inactive categories in Hospitality Hub admin dropdown

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/HospitalityHubAdminClientInner.tsx
@@ -34,7 +34,7 @@ export const HospitalityHubAdminClientInner = () => {
   const [editingCategory, setEditingCategory] =
     useState<HospitalityCategory | null>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const { categories, loading, refresh } = useHospitalityCategories();
+  const { categories, loading, refresh } = useHospitalityCategories([], true);
   const [selectedCategory, setSelectedCategory] =
     useState<HospitalityCategory | null>(null);
   const itemTabRef = useRef<CategoryTabContentRef>(null);

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityCategories.ts
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/hooks/useHospitalityCategories.ts
@@ -1,9 +1,12 @@
 import { useState, useEffect } from "react";
 import { HospitalityCategory } from "@/types/hospitalityHub";
 
-export function useHospitalityCategories(initialCategories: HospitalityCategory[] = []) {
+export function useHospitalityCategories(
+  initialCategories: HospitalityCategory[] = [],
+  includeInactive = false,
+) {
   const [categories, setCategories] = useState<HospitalityCategory[]>(
-    initialCategories.filter((c) => c.isActive),
+    initialCategories.filter((c) => includeInactive || c.isActive),
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -11,13 +14,13 @@ export function useHospitalityCategories(initialCategories: HospitalityCategory[
   const fetchCategories = async () => {
     setLoading(true);
     try {
-      const res = await fetch('/api/hospitality-hub/categories');
+      const res = await fetch("/api/hospitality-hub/categories");
       const data = await res.json();
       if (res.ok) {
         const fetched: HospitalityCategory[] = data.resource || [];
-        setCategories(fetched.filter((cat) => cat.isActive));
+        setCategories(fetched.filter((cat) => includeInactive || cat.isActive));
       } else {
-        throw new Error(data?.error || 'Failed to fetch categories');
+        throw new Error(data?.error || "Failed to fetch categories");
       }
     } catch (err: any) {
       console.error(err);


### PR DESCRIPTION
## Summary
- include inactive categories when fetching hospitality categories if requested
- display inactive categories in the Hospitality Hub admin dropdown

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6852d9ffcf208326a4340e4ab4b52eb6