### PR TITLE
Fix detail modal image sizing

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -187,13 +187,15 @@ export const ItemDetailModal = ({
                   </VStack>
                 </MotionVStack>
                 {item?.coverImageUrl && (
-                  <Box position="relative">
+                  <Box position="relative" h="100%">
                     <MotionImage
                       src={item.coverImageUrl}
                       alt={item.name}
                       variants={itemVariants}
                       objectFit="cover"
                       borderRadius="md"
+                      w="100%"
+                      h="100%"
                     />
                     <Box
                       position="absolute"


### PR DESCRIPTION
## Summary
- ensure the detail modal's cover image fills the available space

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e2974e0c8326b39f473f8ad9749b