### PR TITLE
Show existing images in item modal

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -85,6 +85,10 @@ export default function AddItemModal({
   const [logoFile, setLogoFile] = useState<File | null>(null);
   const [coverFile, setCoverFile] = useState<File | null>(null);
   const [additionalFiles, setAdditionalFiles] = useState<File[]>([]);
+  const [existingLogoUrl, setExistingLogoUrl] = useState<string | null>(null);
+  const [existingCoverUrl, setExistingCoverUrl] = useState<string | null>(null);
+  const [removeLogoUrl, setRemoveLogoUrl] = useState<string | null>(null);
+  const [removeCoverUrl, setRemoveCoverUrl] = useState<string | null>(null);
 
   const customerId = user?.customerId;
   const userId = user?.userId;
@@ -113,7 +117,8 @@ export default function AddItemModal({
       setValue("endDate", item.endDate ? item.endDate.slice(0, 10) : "");
       setValue("location", item.location || "");
       setValue("handlerUserId", item.itemOwnerUserId ?? null);
-      // Existing images are server‑side only, ignore client‑side
+      setExistingLogoUrl(item.logoImageUrl || null);
+      setExistingCoverUrl(item.coverImageUrl || null);
     } else {
       reset({
         name: "",
@@ -128,11 +133,15 @@ export default function AddItemModal({
         customerId: customerId ?? undefined,
         itemOwnerUserId: userId ?? undefined,
       });
+      setExistingLogoUrl(null);
+      setExistingCoverUrl(null);
     }
 
     setLogoFile(null);
     setCoverFile(null);
     setAdditionalFiles([]);
+    setRemoveLogoUrl(null);
+    setRemoveCoverUrl(null);
     // eslint‑disable‑next‑line react‑hooks/exhaustive‑deps
   }, [item, isOpen]);
 
@@ -140,6 +149,30 @@ export default function AddItemModal({
     if (!user?.customerUniqueId) {
       toast({
         title: "Missing customer information.",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+      return;
+    }
+
+    if (removeLogoUrl && !logoFile) {
+      toast({
+        title: "Logo image required",
+        description: "Please upload a new logo image after removing the existing one.",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+      return;
+    }
+
+    if (removeCoverUrl && !coverFile) {
+      toast({
+        title: "Cover image required",
+        description: "Please upload a new cover image after removing the existing one.",
         status: "error",
         duration: 5000,
         isClosable: true,
@@ -170,6 +203,8 @@ export default function AddItemModal({
       // Images
       if (logoFile) formData.append("logoImageUpload", logoFile);
       if (coverFile) formData.append("coverImageUpload", coverFile);
+      if (removeLogoUrl) formData.append("removeLogoImage", removeLogoUrl);
+      if (removeCoverUrl) formData.append("removeCoverImage", removeCoverUrl);
       additionalFiles.forEach((file) =>
         formData.append("additionalImages", file)
       );
@@ -312,10 +347,22 @@ export default function AddItemModal({
             <ImageUploadWithCrop
               label="Logo Image"
               onFileSelected={(file) => setLogoFile(file)}
+              isRequired={!existingLogoUrl}
+              existingUrl={existingLogoUrl || undefined}
+              onRemoveExisting={() => {
+                if (existingLogoUrl) setRemoveLogoUrl(existingLogoUrl);
+                setExistingLogoUrl(null);
+              }}
             />
             <ImageUploadWithCrop
               label="Cover Image"
               onFileSelected={(file) => setCoverFile(file)}
+              isRequired={!existingCoverUrl}
+              existingUrl={existingCoverUrl || undefined}
+              onRemoveExisting={() => {
+                if (existingCoverUrl) setRemoveCoverUrl(existingCoverUrl);
+                setExistingCoverUrl(null);
+              }}
             />
             <FormControl mb={4}>
               <FormLabel>Additional Images</FormLabel>

--- a/src/components/image/ImageUploadWithCrop.tsx
+++ b/src/components/image/ImageUploadWithCrop.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import {
   FormControl,
   FormLabel,
@@ -19,16 +19,23 @@ interface Props {
   label: string;
   onFileSelected: (file: File | null) => void;
   isRequired?: boolean;
+  /** Existing image URL to display when editing */
+  existingUrl?: string;
+  /** Called when an existing image is removed */
+  onRemoveExisting?: () => void;
 }
 
 export default function ImageUploadWithCrop({
   label,
   onFileSelected,
   isRequired = false,
+  existingUrl,
+  onRemoveExisting,
 }: Props) {
   const [file, setFile] = useState<File | null>(null);
   const [cropOpen, setCropOpen] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string>("");
+  const [usingExisting, setUsingExisting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const borderColor = useColorModeValue("gray.400", "gray.600");
   const hoverBorderColor = useColorModeValue("gray.200", "gray.400");
@@ -65,6 +72,7 @@ export default function ImageUploadWithCrop({
     setCropOpen(false);
     setFile(null);
     setPreviewUrl(URL.createObjectURL(cropped));
+    setUsingExisting(false);
     onFileSelected(cropped);
   };
 
@@ -75,10 +83,24 @@ export default function ImageUploadWithCrop({
 
   const handleRemove = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (usingExisting && onRemoveExisting) {
+      onRemoveExisting();
+    }
     setPreviewUrl("");
+    setUsingExisting(false);
     setFile(null);
     onFileSelected(null);
   };
+
+  useEffect(() => {
+    if (existingUrl) {
+      setPreviewUrl(existingUrl);
+      setUsingExisting(true);
+    } else {
+      setPreviewUrl("");
+      setUsingExisting(false);
+    }
+  }, [existingUrl]);
 
   return (
     <FormControl mb={4} isRequired={isRequired}>


### PR DESCRIPTION
## Summary
- support showing an existing file in `ImageUploadWithCrop`
- allow removing the existing logo/cover images in the hospitality hub item form
- ensure a new file is required after removing an existing image

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853bffc79588326a891f6a5506ff61d