### PR TITLE
Fetch team members in AddItemModal

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -108,12 +108,7 @@ export default function AddItemModal({
         const data = await res.json();
         if (res.ok) {
           const list = (data.resource ?? data) as any[];
-          const mapped = list.map((m) => ({
-            id: m.userId ?? m.id,
-            imageUrl: m.userImageUrl ?? m.imageUrl,
-            fullName: m.userFullname ?? m.fullName,
-          }));
-          setTeamMembers(mapped);
+          setTeamMembers(list);
         } else {
           toast({
             title: "Failed to fetch team members.",


### PR DESCRIPTION
## Summary
- enable handler autocomplete in Hospitality Hub item modal
- fetch team members from `/api/getForTeamMemberInput` when the modal opens

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e6c50ea883269b3b3d7cbab380e8