### PR TITLE
Support multiple additional image uploads

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -198,9 +198,9 @@ export default function AddItemModal({
       // Images
       if (logoFile) formData.append("logoImageUpload", logoFile);
       if (coverFile) formData.append("coverImageUpload", coverFile);
-      additionalFiles.forEach((file) =>
-        formData.append("additionalImages", file)
-      );
+      additionalFiles.forEach((file) => {
+        formData.append("AdditionalImagesListUpload[]", file);
+      });
 
       const res = await fetch("/api/hospitality-hub/items", {
         method,


### PR DESCRIPTION
## Summary
- allow multiple additional images
- show thumbnails and remove button for each image in drag & drop input
- send each additional image as `AdditionalImagesListUpload[]` to API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e7e90d4c83269cd36865e8e1362e