### PR TITLE
Add booking owner and booker details

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/BookingModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/BookingModal.tsx
@@ -45,6 +45,9 @@ function SingleDayBookingForm({ item, onClose, submit }: BookingFormProps) {
         <input type="hidden" value={item.id} {...register("userHospitalityItemId")} />
         <input type="hidden" value={user?.customerId ?? 0} {...register("customerId")} />
         <input type="hidden" value={item.itemType} {...register("bookingType")} />
+        <input type="hidden" value={item.itemType} {...register("itemType")} />
+        <input type="hidden" value={user?.userId ?? 0} {...register("bookerId")} />
+        <input type="hidden" value={(item.itemOwnerUserId as any) || (item as any).catOwnerUserId || 0} {...register("ownerId")} />
 
         <FormControl mb={4}>
           <FormLabel>Date</FormLabel>
@@ -83,6 +86,9 @@ function MultiDayBookingForm({ item, onClose, submit }: BookingFormProps) {
         <input type="hidden" value={item.id} {...register("userHospitalityItemId")} />
         <input type="hidden" value={user?.customerId ?? 0} {...register("customerId")} />
         <input type="hidden" value={item.itemType} {...register("bookingType")} />
+        <input type="hidden" value={item.itemType} {...register("itemType")} />
+        <input type="hidden" value={user?.userId ?? 0} {...register("bookerId")} />
+        <input type="hidden" value={(item.itemOwnerUserId as any) || (item as any).catOwnerUserId || 0} {...register("ownerId")} />
 
         <FormControl mb={4}>
           <FormLabel>Start Date</FormLabel>
@@ -126,6 +132,9 @@ function SingleDayWithStartEndBookingForm({ item, onClose, submit }: BookingForm
         <input type="hidden" value={item.id} {...register("userHospitalityItemId")} />
         <input type="hidden" value={user?.customerId ?? 0} {...register("customerId")} />
         <input type="hidden" value={item.itemType} {...register("bookingType")} />
+        <input type="hidden" value={item.itemType} {...register("itemType")} />
+        <input type="hidden" value={user?.userId ?? 0} {...register("bookerId")} />
+        <input type="hidden" value={(item.itemOwnerUserId as any) || (item as any).catOwnerUserId || 0} {...register("ownerId")} />
 
         <FormControl mb={4}>
           <FormLabel>Date</FormLabel>
@@ -170,6 +179,11 @@ export default function BookingModal({ isOpen, onClose, item }: BookingModalProp
     data.userHospitalityItemId = Number(item.id);
     data.customerId = user?.customerId ?? 0;
     data.bookingType = item.itemType;
+    data.itemType = item.itemType;
+    data.bookerId = user?.userId ?? 0;
+    data.ownerId = Number(
+      (item.itemOwnerUserId as any) || (item as any).catOwnerUserId || 0,
+    );
 
     if (data.startTime) {
       data.startTime = data.startTime.replace("T", " ") + ":00";

--- a/src/types/hospitalityHub.ts
+++ b/src/types/hospitalityHub.ts
@@ -25,6 +25,8 @@ export interface HospitalityItem {
   createdBy?: string;
   updatedAt?: string;
   updatedBy?: string;
+  /** Owner of the category this item belongs to */
+  catOwnerUserId?: string;
 }
 
 export interface HospitalityCategory {
@@ -42,6 +44,12 @@ export interface HospitalityBooking {
   info?: string;
   customerId: number;
   bookingType: string;
+  /** Type of the item being booked */
+  itemType?: string;
+  /** ID of the user creating the booking */
+  bookerId?: number;
+  /** Owner of the item or its category */
+  ownerId?: number;
   startDate?: string; // Format: YYYY-MM-DD
   endDate?: string; // Format: YYYY-MM-DD
   startTime?: string; // Format: YYYY-MM-DD HH:mm:ss


### PR DESCRIPTION
## Summary
- extend `HospitalityBooking` to include `itemType`, `bookerId` and `ownerId`
- include new hidden fields in hospitality booking forms
- send the additional fields when submitting a booking

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e8be62cc8326b84318cc69f094cc