### PR TITLE
Fix hospitality item creation with category owner

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -40,6 +40,7 @@ interface AddItemModalProps {
   isOpen: boolean;
   onClose: () => void;
   categoryId: string;
+  catOwnerUserId: string;
   onCreated: () => void;
   // teamMembers: BigUpTeamMember[];
   item?: HospitalityItem | null;
@@ -62,6 +63,7 @@ export default function AddItemModal({
   isOpen,
   onClose,
   categoryId,
+  catOwnerUserId,
   onCreated,
   item,
 }: AddItemModalProps) {
@@ -266,6 +268,10 @@ export default function AddItemModal({
 
     try {
       const method = item ? "PUT" : "POST";
+
+      if (ownerOption === "category") {
+        data.itemOwnerUserId = Number(catOwnerUserId);
+      }
       const formData = new FormData();
 
       // Append simple primitives first

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -271,6 +271,8 @@ export default function AddItemModal({
 
       if (ownerOption === "category") {
         data.itemOwnerUserId = Number(catOwnerUserId);
+      } else if (data.itemOwnerUserId !== undefined) {
+        data.itemOwnerUserId = Number(data.itemOwnerUserId);
       }
       const formData = new FormData();
 
@@ -359,7 +361,6 @@ export default function AddItemModal({
           <ModalBody>
             {/* Hidden fields */}
             <input type="hidden" {...register("customerId")} />
-            <input type="hidden" {...register("itemOwnerUserId")} />
 
             {/* Name */}
             <FormControl mb={4} isRequired>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -105,6 +105,7 @@ export const CategoryTabContent = forwardRef<
         onClose={() => setModalOpen(false)}
         onCreated={handleRefresh}
         categoryId={category.id}
+        catOwnerUserId={category.catOwnerUserId}
         item={editingItem}
       />
       <DeleteItemModal


### PR DESCRIPTION
## Summary
- pass category owner's id to item creation modal
- submit correct owner id when using category owner option

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68541c82cc7c832691e668704c99d662