### PR TITLE
Add owner selection for Hospitality Hub categories

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -45,7 +45,8 @@ export default function AddCategoryModal({
   onCreated,
   category,
 }: AddCategoryModalProps) {
-  const { register, handleSubmit, reset, setValue } = useForm<FormValues>();
+  const { register, control, handleSubmit, reset, setValue } =
+    useForm<FormValues>();
   const toast = useToast();
 
   const { user } = useUser();


### PR DESCRIPTION
## Summary
- allow selecting the owner when adding/updating a hospitality hub category
- fetch available users for the autocomplete and let admins choose themselves or another user

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854363b79508326a0ef84645abfa539