### PR TITLE
Modify hospitality hub detail modal layout

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -19,15 +19,6 @@ import { motion, Variants } from "framer-motion";
 import { HospitalityItem } from "@/types/hospitalityHub";
 import { useState } from "react";
 import BookingModal from "./BookingModal";
-import {
-  Description,
-  HowToReg,
-  Info,
-  CalendarToday,
-  EventAvailable,
-  LocationOn,
-  Category,
-} from "@mui/icons-material";
 
 interface ItemDetailModalProps {
   isOpen: boolean;
@@ -103,6 +94,8 @@ export const ItemDetailModal = ({
                   initial="hidden"
                   animate="visible"
                   p={4}
+                  h="100%"
+                  justify="space-between"
                 >
                   <ModalHeader
                     fontSize="3xl"
@@ -113,14 +106,20 @@ export const ItemDetailModal = ({
                   >
                     {item?.name || "Details"}
                   </ModalHeader>
-                  <VStack align="start" spacing={6} width="100%">
+                  <VStack
+                    align="start"
+                    spacing={6}
+                    width="100%"
+                    flex={1}
+                    justify="space-evenly"
+                  >
                     {item?.description && (
                       <MotionHStack
                         variants={itemVariants}
                         width="100%"
                         alignItems="flex-start"
                       >
-                        <Description />
+                        <Text color="yellow.400" minW="120px">Description:</Text>
                         <Text flex="1">{item.description}</Text>
                       </MotionHStack>
                     )}
@@ -130,7 +129,7 @@ export const ItemDetailModal = ({
                         width="100%"
                         alignItems="flex-start"
                       >
-                        <HowToReg />
+                        <Text color="yellow.400" minW="120px">How To:</Text>
                         <Text flex="1">{item.howToDetails}</Text>
                       </MotionHStack>
                     )}
@@ -140,7 +139,7 @@ export const ItemDetailModal = ({
                         width="100%"
                         alignItems="flex-start"
                       >
-                        <Info />
+                        <Text color="yellow.400" minW="120px">Info:</Text>
                         <Text flex="1">{item.extraDetails}</Text>
                       </MotionHStack>
                     )}
@@ -150,7 +149,7 @@ export const ItemDetailModal = ({
                         width="100%"
                         alignItems="flex-start"
                       >
-                        <CalendarToday />
+                        <Text color="yellow.400" minW="120px">Start:</Text>
                         <Text flex="1">{item.startDate}</Text>
                       </MotionHStack>
                     )}
@@ -160,7 +159,7 @@ export const ItemDetailModal = ({
                         width="100%"
                         alignItems="flex-start"
                       >
-                        <EventAvailable />
+                        <Text color="yellow.400" minW="120px">End:</Text>
                         <Text flex="1">{item.endDate}</Text>
                       </MotionHStack>
                     )}
@@ -170,21 +169,21 @@ export const ItemDetailModal = ({
                         width="100%"
                         alignItems="flex-start"
                       >
-                        <LocationOn />
+                        <Text color="yellow.400" minW="120px">Location:</Text>
                         <Text flex="1">{item.location}</Text>
                       </MotionHStack>
                     )}
-                    {item && ctaText && (
-                      <Box p={4} textAlign="center">
-                        <Button
-                          colorScheme="yellow"
-                          onClick={() => setBookingOpen(true)}
-                        >
-                          {ctaText}
-                        </Button>
-                      </Box>
-                    )}
                   </VStack>
+                  {item && ctaText && (
+                    <Box pt={4} textAlign="center" width="100%">
+                      <Button
+                        colorScheme="yellow"
+                        onClick={() => setBookingOpen(true)}
+                      >
+                        {ctaText}
+                      </Button>
+                    </Box>
+                  )}
                 </MotionVStack>
                 {item?.coverImageUrl && (
                   <Box position="relative" h="100%">

--- a/src/theme/themes/base-theme/baseTheme.ts
+++ b/src/theme/themes/base-theme/baseTheme.ts
@@ -46,6 +46,8 @@ export const baseTheme = extendTheme({
     tooltipBodyTextColor: "primaryTextColor",
     // tooltipBodyBGColor: "white",
 
+    hospitalityHubPremium: "#EFC718",
+
     happinessScale: {
       1: "#b22200",
       2: "#e92300",
@@ -195,11 +197,11 @@ export const baseTheme = extendTheme({
         },
 
         hospitalityHub: {
-          bg: "#EFC718",
+          bg: "hospitalityHubPremium",
           color: "black",
           _hover: {
             backgroundColor: "white",
-            color: "primary",
+            color: "hospitalityHubPremium",
           },
         },
 


### PR DESCRIPTION
## Summary
- update layout for item details modal
- show button at the bottom
- spread details evenly and replace icons with yellow labels

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553686240c83269e1e3db05c78616b