### PR TITLE
Use coverImageUrl in hospitality hub

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -158,7 +158,11 @@ export function HospitalityHubMasonry({
               _hover={{ transform: "scale(1.05)", boxShadow: "2xl" }}
             >
               <Image
-                src={category.imageUrl || (category as any).image}
+                src={
+                  category.coverImageUrl ||
+                  category.imageUrl ||
+                  (category as any).image
+                }
                 alt={category.name}
                 objectFit="cover"
                 w="100%"

--- a/src/types/hospitalityHub.ts
+++ b/src/types/hospitalityHub.ts
@@ -37,7 +37,8 @@ export interface HospitalityCategory {
   customerId: string;
   catOwnerUserId: string;
   isActive: boolean;
-  imageUrl?: string;
+  /** Image representing the category */
+  coverImageUrl?: string;
 }
 
 export interface HospitalityBooking {


### PR DESCRIPTION
## Summary
- add `coverImageUrl` field to `HospitalityCategory` type
- prefer `coverImageUrl` when showing hospitality categories

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553d6698b883268622bac7f8b05195