### PR TITLE
Move Sites field to first column

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddItemModal.tsx
@@ -422,10 +422,7 @@ export default function AddItemModal({
                   <FormLabel>End Date</FormLabel>
                   <Input type="date" {...register("endDate")} />
                 </FormControl>
-              </GridItem>
 
-              <GridItem>
-                {/* Right Column */}
                 {/* Sites */}
                 <FormControl mb={4}>
                   <FormLabel>Sites</FormLabel>
@@ -473,6 +470,10 @@ export default function AddItemModal({
                     </VStack>
                   )}
                 </FormControl>
+              </GridItem>
+
+              <GridItem>
+                {/* Right Column */}
 
                 {/* Owner selection */}
                 <FormControl mb={2}>


### PR DESCRIPTION
## Summary
- tweak AddItemModal layout so Sites input appears in the first column

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_68553e3afc40832691a929a6ee33cfb3