### PR TITLE
Modify Hospitality Hub back button style

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -93,15 +93,19 @@ export function HospitalityHubMasonry({
     return (
       <Center mt={20} mb={10}>
         <Box
-          mb={4}
+          position="fixed"
+          top={4}
+          left={4}
           cursor="pointer"
           onClick={() => {
             setSelected(null);
           }}
-          _hover={{ transform: "scale(1.1)" }}
+          p={2}
+          zIndex={1}
+          _hover={{ transform: "scale(1.05)" }}
           transition="transform 0.2s"
         >
-          <Text fontWeight="bold" color="hospitalityHubPremium">
+          <Text fontWeight="bold" fontSize="2xl" color="hospitalityHubPremium">
             &larr; Back
           </Text>
         </Box>


### PR DESCRIPTION
## Summary
- position the Hospitality Hub masonry back button at the top left of the page
- increase the size of the back button text

## Testing
- `npm test --silent`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685541b9d8a88326adbeb232ecd8bac0