### PR TITLE
Fix Hospitality Hub category upload handling

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/AddCategoryModal.tsx
@@ -146,43 +146,54 @@ export default function AddCategoryModal({
     if (category) formData.append("id", category.id);
     if (coverFile) formData.append("coverImageUpload", coverFile);
 
-    const res = await fetch("/api/hospitality-hub/categories", {
-      method,
-      body: formData,
-    });
+    try {
+      const res = await fetch("/api/hospitality-hub/categories", {
+        method,
+        body: formData,
+      });
 
-    const result = await res.json();
+      const result = await res.json();
 
-    if (!res.ok) {
+      if (!res.ok) {
+        toast({
+          title:
+            result.error ||
+            (category
+              ? "Failed to update category."
+              : "Failed to create category."),
+          description: result.details,
+          status: "error",
+          duration: 5000,
+          isClosable: true,
+          position: "bottom-right",
+        });
+        return;
+      }
+
       toast({
-        title:
-          result.error ||
-          (category
-            ? "Failed to update category."
-            : "Failed to create category."),
-        description: result.details,
+        title: category
+          ? "Category updated successfully."
+          : "Category created successfully.",
+        status: "success",
+        duration: 5000,
+        isClosable: true,
+        position: "bottom-right",
+      });
+
+      onCreated();
+      reset();
+      setCoverFile(null);
+      onClose();
+    } catch (err) {
+      console.error(err);
+      toast({
+        title: "Failed to upload image.",
         status: "error",
         duration: 5000,
         isClosable: true,
         position: "bottom-right",
       });
-      return;
     }
-
-    toast({
-      title: category
-        ? "Category updated successfully."
-        : "Category created successfully.",
-      status: "success",
-      duration: 5000,
-      isClosable: true,
-      position: "bottom-right",
-    });
-
-    onCreated();
-    reset();
-    setCoverFile(null);
-    onClose();
   };
 
   return (

--- a/src/app/api/hospitality-hub/categories/route.ts
+++ b/src/app/api/hospitality-hub/categories/route.ts
@@ -129,7 +129,7 @@ export async function PUT(req: NextRequest) {
       response = await fetch(
         `${process.env.BE_URL}/userHospitalityCategory/${id}`,
         {
-          method: "PUT",
+          method: "POST",
           headers: {
             Authorization: authToken ? `Bearer ${authToken}` : "",
           },
@@ -146,7 +146,7 @@ export async function PUT(req: NextRequest) {
       response = await fetch(
         `${process.env.BE_URL}/userHospitalityCategory/${id}`,
         {
-          method: "PUT",
+          method: "POST",
           headers: {
             Authorization: authToken ? `Bearer ${authToken}` : "",
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- handle unexpected responses when uploading categories
- use POST for updating categories to match item behavior

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685547a206c0832692ffcf117cb35fdb