### PR TITLE
Add empty items message

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -53,7 +53,7 @@ export const CategoryTabContent = forwardRef<
   }
 
   return (
-    <VStack w="100%" align="stretch" spacing={4}>
+    <VStack w="100%" align="stretch" spacing={4} flex={1}>
       {loading && items.length > 0 && <Spinner size="sm" alignSelf="center" />}
       {loading && items.length === 0 ? (
         <Spinner />

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Spinner, VStack, useToast } from "@chakra-ui/react";
+import { Spinner, VStack, useToast, Center, Text } from "@chakra-ui/react";
 import HospitalityItemsMasonry from "./HospitalityItemsMasonry";
 import { HospitalityCategory, HospitalityItem } from "@/types/hospitalityHub";
 import useHospitalityItems from "../../hooks/useHospitalityItems";
@@ -57,6 +57,17 @@ export const CategoryTabContent = forwardRef<
       {loading && items.length > 0 && <Spinner size="sm" alignSelf="center" />}
       {loading && items.length === 0 ? (
         <Spinner />
+      ) : items.length === 0 ? (
+        <Center flex={1}>
+          <Text
+            fontFamily="bonfire"
+            fontSize="5xl"
+            textAlign="center"
+            color="white"
+          >
+            No items to show!
+          </Text>
+        </Center>
       ) : (
         <HospitalityItemsMasonry
           items={items}


### PR DESCRIPTION
## Summary
- show a "No items to show!" message when a category is selected but contains no items

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68554b934e708326a9c14b7cf7d609c2