### PR TITLE
Fix repeating gradient in Hospitality Hub admin

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/page.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/page.tsx
@@ -1,10 +1,5 @@
-import { PerygonContainer } from "@/components/layout/PerygonContainer";
 import { HospitalityHubAdminClientInner } from "./components/HospitalityHubAdminClientInner";
 
 export default function HospitalityHubAdminPage() {
-  return (
-    <PerygonContainer>
-      <HospitalityHubAdminClientInner />
-    </PerygonContainer>
-  );
+  return <HospitalityHubAdminClientInner />;
 }


### PR DESCRIPTION
## Summary
- remove unnecessary `PerygonContainer` wrapper from Hospitality Hub admin page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554be1ae8883269bf767750f39adb0