### PR TITLE
Add Hospitality Hub masonry heading

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -63,6 +63,7 @@ export function HospitalityHubMasonry({
   const { categories, loading: categoriesLoading } =
     useHospitalityCategories(initialCategories);
   const { items, loading } = useHospitalityItems(selected);
+  const selectedCategoryData = categories.find((cat) => cat.id === selected);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
   const [loadingItemId, setLoadingItemId] = useState<string | null>(null);
@@ -196,25 +197,32 @@ export function HospitalityHubMasonry({
             </option>
           ))}
         </Select>
-        <SimpleGrid
-          columns={[1, null, 2, 3]}
-          gap={6}
-          w="100%"
-          maxW="2000px"
-          mx="auto"
-        >
-          <AnimatedList>
-            {displayedItems.map((item, index) => (
-              <AnimatedListItem key={item.id} index={index}>
-                <MasonryItemCard
-                  item={item}
-                  onClick={() => handleItemClick(item.id)}
-                  loading={loadingItemId === item.id}
-                />
-              </AnimatedListItem>
-            ))}
-          </AnimatedList>
-        </SimpleGrid>
+        <Box w="100%" maxW="2000px" mx="auto">
+          {selectedCategoryData && (
+            <Text
+              fontFamily="bonfire"
+              fontSize="5xl"
+              textAlign="left"
+              color="hospitalityHubPremium"
+              mb={4}
+            >
+              {selectedCategoryData.name}
+            </Text>
+          )}
+          <SimpleGrid columns={[1, null, 2, 3]} gap={6} w="100%">
+            <AnimatedList>
+              {displayedItems.map((item, index) => (
+                <AnimatedListItem key={item.id} index={index}>
+                  <MasonryItemCard
+                    item={item}
+                    onClick={() => handleItemClick(item.id)}
+                    loading={loadingItemId === item.id}
+                  />
+                </AnimatedListItem>
+              ))}
+            </AnimatedList>
+          </SimpleGrid>
+        </Box>
         <ItemDetailModal
           isOpen={modalOpen}
           onClose={() => {


### PR DESCRIPTION
## Summary
- show selected Hospitality Hub category name above item masonry

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555e3357808326ad08ed406292f2f2