### PR TITLE
Fix missing display name warning

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/admin/components/CategoryTabContent.tsx
@@ -128,4 +128,6 @@ export const CategoryTabContent = forwardRef<
   );
 });
 
+CategoryTabContent.displayName = "CategoryTabContent";
+
 export default CategoryTabContent;


### PR DESCRIPTION
## Summary
- add a `displayName` to `CategoryTabContent` to satisfy ESLint

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68555f4199048326b8790a4ff93d3dd9