### PR TITLE
Delay Hospitality detail modal until location fetch

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -69,6 +69,7 @@ export function HospitalityHubMasonry({
   const [selectedItem, setSelectedItem] = useState<HospitalityItem | null>(
     null,
   );
+  const [selectedItemSites, setSelectedItemSites] = useState<string[]>([]);
   const [sites, setSites] = useState<Site[]>([]);
   const [selectedSiteId, setSelectedSiteId] = useState<number | "">("");
 
@@ -104,13 +105,29 @@ export function HospitalityHubMasonry({
         const additional = Array.isArray(item.additionalImageUrlList)
           ? item.additionalImageUrlList
           : typeof item.additionalImageUrlList === "string"
-            ? item.additionalImageUrlList
-                .split(",")
-                .map((u: string) => u.trim())
-                .filter(Boolean)
-            : [];
+              ? item.additionalImageUrlList
+                  .split(",")
+                  .map((u: string) => u.trim())
+                  .filter(Boolean)
+              : [];
         urls.push(...additional);
         await preloadImages(urls);
+        let names: string[] = [];
+        if (item.siteIds && item.siteIds.length > 0) {
+          const query = item.siteIds.map((id: any) => `id=${id}`).join("&");
+          try {
+            const siteRes = await fetch(
+              `/api/site/allBy?selectColumns=id,siteName&${query}`,
+            );
+            const siteData = await siteRes.json();
+            if (siteRes.ok) {
+              names = (siteData.resource || []).map((s: any) => s.siteName);
+            }
+          } catch (err) {
+            console.error(err);
+          }
+        }
+        setSelectedItemSites(names);
         setModalOpen(true);
       }
     } catch (err) {
@@ -220,8 +237,10 @@ export function HospitalityHubMasonry({
           onClose={() => {
             setModalOpen(false);
             setSelectedItem(null);
+            setSelectedItemSites([]);
           }}
           item={selectedItem}
+          siteNames={selectedItemSites}
           loading={modalLoading}
         />
       </Center>

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -17,13 +17,14 @@ import {
 } from "@chakra-ui/react";
 import { motion, Variants } from "framer-motion";
 import { HospitalityItem } from "@/types/hospitalityHub";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import BookingModal from "./BookingModal";
 
 interface ItemDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   item?: HospitalityItem | null;
+  siteNames?: string[];
   loading?: boolean;
 }
 
@@ -51,34 +52,10 @@ export const ItemDetailModal = ({
   isOpen,
   onClose,
   item,
+  siteNames = [],
   loading,
 }: ItemDetailModalProps) => {
   const [bookingOpen, setBookingOpen] = useState(false);
-  const [siteNames, setSiteNames] = useState<string[]>([]);
-
-  useEffect(() => {
-    const fetchSites = async () => {
-      if (!item?.siteIds || item.siteIds.length === 0) {
-        setSiteNames([]);
-        return;
-      }
-
-      const query = item.siteIds.map((id) => `id=${id}`).join("&");
-      try {
-        const res = await fetch(
-          `/api/site/allBy?selectColumns=id,siteName&${query}`,
-        );
-        const data = await res.json();
-        if (res.ok) {
-          setSiteNames((data.resource || []).map((s: any) => s.siteName));
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    };
-
-    fetchSites();
-  }, [item]);
 
   const ctaText =
     item?.itemType === "info"


### PR DESCRIPTION
## Summary
- pass site names to item detail modal instead of fetching internally
- load location names when fetching item details before opening modal

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555ec4d1f88326b3ddac4813a2e0ff