### PR TITLE
Update Hospitality hub item modal behavior

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -70,6 +70,9 @@ export function HospitalityHubMasonry({
   const [selectedItem, setSelectedItem] = useState<HospitalityItem | null>(
     null
   );
+  const [selectedItemSiteNames, setSelectedItemSiteNames] = useState<string[]>(
+    []
+  );
   const [sites, setSites] = useState<Site[]>([]);
   const [selectedSiteId, setSelectedSiteId] = useState<number | "">("");
 
@@ -112,6 +115,30 @@ export function HospitalityHubMasonry({
             : [];
         urls.push(...additional);
         await preloadImages(urls);
+
+        // Fetch site names before opening modal
+        if (item.siteIds && item.siteIds.length > 0) {
+          const query = item.siteIds.map((id: number) => `id=${id}`).join("&");
+          try {
+            const siteRes = await fetch(
+              `/api/site/allBy?selectColumns=id,siteName&${query}`,
+            );
+            const siteData = await siteRes.json();
+            if (siteRes.ok) {
+              setSelectedItemSiteNames(
+                (siteData.resource || []).map((s: any) => s.siteName),
+              );
+            } else {
+              setSelectedItemSiteNames([]);
+            }
+          } catch (err) {
+            console.error(err);
+            setSelectedItemSiteNames([]);
+          }
+        } else {
+          setSelectedItemSiteNames([]);
+        }
+
         setModalOpen(true);
       }
     } catch (err) {
@@ -242,9 +269,11 @@ export function HospitalityHubMasonry({
               onClose={() => {
                 setModalOpen(false);
                 setSelectedItem(null);
+                setSelectedItemSiteNames([]);
               }}
               item={selectedItem}
               loading={modalLoading}
+              siteNames={selectedItemSiteNames}
             />
           </>
         )}

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -17,7 +17,7 @@ import {
 } from "@chakra-ui/react";
 import { motion, Variants } from "framer-motion";
 import { HospitalityItem } from "@/types/hospitalityHub";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import BookingModal from "./BookingModal";
 
 interface ItemDetailModalProps {
@@ -25,6 +25,7 @@ interface ItemDetailModalProps {
   onClose: () => void;
   item?: HospitalityItem | null;
   loading?: boolean;
+  siteNames?: string[];
 }
 
 const containerVariants: Variants = {
@@ -52,33 +53,10 @@ export const ItemDetailModal = ({
   onClose,
   item,
   loading,
+  siteNames: siteNamesProp,
 }: ItemDetailModalProps) => {
   const [bookingOpen, setBookingOpen] = useState(false);
-  const [siteNames, setSiteNames] = useState<string[]>([]);
-
-  useEffect(() => {
-    const fetchSites = async () => {
-      if (!item?.siteIds || item.siteIds.length === 0) {
-        setSiteNames([]);
-        return;
-      }
-
-      const query = item.siteIds.map((id) => `id=${id}`).join("&");
-      try {
-        const res = await fetch(
-          `/api/site/allBy?selectColumns=id,siteName&${query}`,
-        );
-        const data = await res.json();
-        if (res.ok) {
-          setSiteNames((data.resource || []).map((s: any) => s.siteName));
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    };
-
-    fetchSites();
-  }, [item]);
+  const siteNames = siteNamesProp || [];
 
   const ctaText =
     item?.itemType === "info"


### PR DESCRIPTION
## Summary
- fetch location names on item click before showing detail modal
- accept `siteNames` prop in `ItemDetailModal`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556251fd4883269a44dd3c9fb7444c