### PR TITLE
Fix Hospitality Hub site id parsing

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -131,10 +131,13 @@ export function HospitalityHubMasonry({
 
     const displayedItems = items.filter((item) => {
       if (!selectedSiteId) return true;
-      const ids = Array.isArray(item.siteIds)
-        ? item.siteIds
-        : typeof item.siteIds === "string"
-          ? item.siteIds
+      const rawSiteIds = item.siteIds as string[] | number[] | string | undefined;
+      const ids = Array.isArray(rawSiteIds)
+        ? rawSiteIds
+            .map((s) => Number(s))
+            .filter((n) => !isNaN(n))
+        : typeof rawSiteIds === "string"
+          ? rawSiteIds
               .split(",")
               .map((s) => Number(s.trim()))
               .filter((n) => !isNaN(n))

--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/ItemDetailModal.tsx
@@ -58,12 +58,27 @@ export const ItemDetailModal = ({
 
   useEffect(() => {
     const fetchSites = async () => {
-      if (!item?.siteIds || item.siteIds.length === 0) {
+      const rawSiteIds = item?.siteIds as string[] | number[] | string | undefined;
+      if (!rawSiteIds) {
         setSiteNames([]);
         return;
       }
 
-      const query = item.siteIds.map((id) => `id=${id}`).join("&");
+      const ids = Array.isArray(rawSiteIds)
+        ? rawSiteIds.map((s) => Number(s)).filter((n) => !isNaN(n))
+        : typeof rawSiteIds === "string"
+          ? rawSiteIds
+              .split(",")
+              .map((s) => Number(s.trim()))
+              .filter((n) => !isNaN(n))
+          : [];
+
+      if (ids.length === 0) {
+        setSiteNames([]);
+        return;
+      }
+
+      const query = ids.map((id) => `id=${id}`).join("&");
       try {
         const res = await fetch(
           `/api/site/allBy?selectColumns=id,siteName&${query}`,

--- a/src/types/hospitalityHub.ts
+++ b/src/types/hospitalityHub.ts
@@ -11,7 +11,12 @@ export interface HospitalityItem {
   startDate?: string;
   endDate?: string | null;
   location?: string;
-  siteIds?: number[];
+  /**
+   * Associated site IDs. The API may return this as an array of numbers,
+   * an array of numeric strings or a comma separated string, so allow for
+   * those shapes here.
+   */
+  siteIds?: number[] | string[] | string;
   itemType:
     | "singleDayBookable"
     | "singleDayBookableWithStartEnd"


### PR DESCRIPTION
## Summary
- update `HospitalityItem` to allow string formats for site IDs
- normalise `siteIds` when filtering items
- handle non-array `siteIds` in `ItemDetailModal`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855631567bc8326ac23dbd1ec405652