### PR TITLE
Fix missing controls on HospitalityHub empty masonry

### DIFF
--- a/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
+++ b/src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx
@@ -68,10 +68,10 @@ export function HospitalityHubMasonry({
   const [modalLoading, setModalLoading] = useState(false);
   const [loadingItemId, setLoadingItemId] = useState<string | null>(null);
   const [selectedItem, setSelectedItem] = useState<HospitalityItem | null>(
-    null
+    null,
   );
   const [selectedItemSiteNames, setSelectedItemSiteNames] = useState<string[]>(
-    []
+    [],
   );
   const [sites, setSites] = useState<Site[]>([]);
   const [selectedSiteId, setSelectedSiteId] = useState<number | "">("");
@@ -178,6 +178,60 @@ export function HospitalityHubMasonry({
 
     return (
       <Center mt={20} mb={10}>
+        <Box
+          position="fixed"
+          top={71}
+          left={10}
+          cursor="pointer"
+          onClick={() => {
+            setSelected(null);
+          }}
+          p={2}
+          zIndex={1}
+          _hover={{ transform: "scale(1.05)" }}
+          transition="transform 0.2s"
+          mb={10}
+        >
+          <Text
+            bgColor="rgba(0, 0, 0, 0.57)"
+            fontWeight="bold"
+            fontSize="2xl"
+            color="hospitalityHubPremium"
+            p={3}
+            borderRadius="lg"
+            fontFamily="Metropolis"
+          >
+            &larr; Back
+          </Text>
+        </Box>
+        <Select
+          position="fixed"
+          top={150}
+          left={10}
+          w="200px"
+          zIndex={1}
+          bg="gray.700"
+          color="hospitalityHubPremium"
+          borderColor="hospitalityHubPremium"
+          borderWidth="1px"
+          value={selectedSiteId}
+          onChange={(e) =>
+            setSelectedSiteId(e.target.value ? Number(e.target.value) : "")
+          }
+        >
+          <option style={{ backgroundColor: "black" }} value="">
+            All Sites
+          </option>
+          {sites.map((site) => (
+            <option
+              key={site.id}
+              value={site.id}
+              style={{ backgroundColor: "black" }}
+            >
+              {site.siteName}
+            </option>
+          ))}
+        </Select>
         {displayedItems.length === 0 ? (
           <Center flex={1} w="100%">
             <Text
@@ -190,100 +244,44 @@ export function HospitalityHubMasonry({
             </Text>
           </Center>
         ) : (
-          <>
-            <Box
-              position="fixed"
-              top={71}
-              left={10}
-              cursor="pointer"
-              onClick={() => {
-                setSelected(null);
-              }}
-              p={2}
-              zIndex={1}
-              _hover={{ transform: "scale(1.05)" }}
-              transition="transform 0.2s"
-              mb={10}
-            >
+          <Box w="100%" maxW="2000px" mx="auto">
+            {selectedCategoryData && (
               <Text
-                bgColor="rgba(0, 0, 0, 0.57)"
-                fontWeight="bold"
-                fontSize="2xl"
+                fontFamily="bonfire"
+                fontSize="5xl"
+                textAlign="left"
                 color="hospitalityHubPremium"
-                p={3}
-                borderRadius="lg"
-                fontFamily="Metropolis"
+                mb={4}
               >
-                &larr; Back
+                {selectedCategoryData.name}
               </Text>
-            </Box>
-            <Select
-              position="fixed"
-              top={150}
-              left={10}
-              w="200px"
-              zIndex={1}
-              bg="gray.700"
-              color="hospitalityHubPremium"
-              borderColor="hospitalityHubPremium"
-              borderWidth="1px"
-              value={selectedSiteId}
-              onChange={(e) =>
-                setSelectedSiteId(e.target.value ? Number(e.target.value) : "")
-              }
-            >
-              <option style={{ backgroundColor: "black" }} value="">
-                All Sites
-              </option>
-              {sites.map((site) => (
-                <option
-                  key={site.id}
-                  value={site.id}
-                  style={{ backgroundColor: "black" }}
-                >
-                  {site.siteName}
-                </option>
-              ))}
-            </Select>
-            <Box w="100%" maxW="2000px" mx="auto">
-              {selectedCategoryData && (
-                <Text
-                  fontFamily="bonfire"
-                  fontSize="5xl"
-                  textAlign="left"
-                  color="hospitalityHubPremium"
-                  mb={4}
-                >
-                  {selectedCategoryData.name}
-                </Text>
-              )}
-              <SimpleGrid columns={[1, null, 2, 3]} gap={6} w="100%">
-                <AnimatedList>
-                  {displayedItems.map((item, index) => (
-                    <AnimatedListItem key={item.id} index={index}>
-                      <MasonryItemCard
-                        item={item}
-                        onClick={() => handleItemClick(item.id)}
-                        loading={loadingItemId === item.id}
-                      />
-                    </AnimatedListItem>
-                  ))}
-                </AnimatedList>
-              </SimpleGrid>
-            </Box>
-            <ItemDetailModal
-              isOpen={modalOpen}
-              onClose={() => {
-                setModalOpen(false);
-                setSelectedItem(null);
-                setSelectedItemSiteNames([]);
-              }}
-              item={selectedItem}
-              loading={modalLoading}
-              siteNames={selectedItemSiteNames}
-            />
-          </>
+            )}
+            <SimpleGrid columns={[1, null, 2, 3]} gap={6} w="100%">
+              <AnimatedList>
+                {displayedItems.map((item, index) => (
+                  <AnimatedListItem key={item.id} index={index}>
+                    <MasonryItemCard
+                      item={item}
+                      onClick={() => handleItemClick(item.id)}
+                      loading={loadingItemId === item.id}
+                    />
+                  </AnimatedListItem>
+                ))}
+              </AnimatedList>
+            </SimpleGrid>
+          </Box>
         )}
+        <ItemDetailModal
+          isOpen={modalOpen}
+          onClose={() => {
+            setModalOpen(false);
+            setSelectedItem(null);
+            setSelectedItemSiteNames([]);
+          }}
+          item={selectedItem}
+          loading={modalLoading}
+          siteNames={selectedItemSiteNames}
+        />
       </Center>
     );
   }


### PR DESCRIPTION
## Summary
- adjust HospitalityHubMasonry so Back button and site filter dropdown render even when there are no results

## Testing
- `npx prettier -w src/app/(site)/(apps-non-standard)/hospitality-hub/app/components/HospitalityHubMasonry.tsx`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556792988883269d88486aaaaa4019